### PR TITLE
Bash 3 compatibility

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,6 +1,34 @@
 #!/usr/bin/env bash
 set -e
 
-if bats test/*.bats; then
-  ./gh-signoff tests
+# Directory containing this script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$DIR")"
+DOCKER_DIR="$REPO_ROOT/test/docker"
+
+PASSED=true
+
+for version in 3 4 5; do
+  echo -e "\n\033[1;35mBash $version\033[0m"
+
+  docker build --quiet --pull -t "gh-signoff-test:bash$version" \
+    --build-arg "BASH_VERSION=$version" \
+    -f "$DOCKER_DIR/Dockerfile" \
+    "$DOCKER_DIR" >/dev/null
+
+  if docker run --rm -v "$REPO_ROOT:/app" "gh-signoff-test:bash$version"; then
+    echo "✅ Tests passed for Bash $version"
+    ./gh-signoff "bash-$version" || true
+  else
+    echo "❌ Tests failed for Bash $version"
+    PASSED=false
+  fi
+done
+
+if $PASSED; then
+  echo -e "\n✅ Tests passed for all Bash versions"
+  ./gh-signoff
+  exit 0
+else
+  exit 1
 fi

--- a/gh-signoff
+++ b/gh-signoff
@@ -427,12 +427,17 @@ cmd_status() {
     done < <(echo "$protection" | jq -r '.required_status_checks?.contexts? | map(select(startswith("signoff"))) | .[]?' 2>/dev/null || echo "")
   fi
 
-  # Create a map of actual contexts and their states
-  declare -A context_states
-  while read -r context state; do
+  # Extract context/state pairs into a string-based lookup map
+  # Format: "context1=state1;context2=state2;..."
+  # This is a lightweight alternative to associative arrays for Bash 3
+  local context_map=""
+
+  # Extract all contexts with success state
+  while IFS=$'\t' read -r context state; do
     [[ -z "$context" ]] && continue
-    context_states["$context"]="$state"
-  done < <(echo "$statuses" | jq -r '.statuses[]? | select(.context? | startswith("signoff")) | [.context, .state] | @tsv' 2>/dev/null)
+    # Add to our string-based map
+    context_map="${context_map}${context}=${state};"
+  done < <(echo "$statuses" | jq -r '.statuses[]? | select(.context? | startswith("signoff")) | [.context, .state] | @tsv' 2>/dev/null || echo "")
 
   # Add any actual contexts that aren't in required list
   while read -r context; do
@@ -451,7 +456,7 @@ cmd_status() {
     if [[ "$found" == "false" ]]; then
       required+=("$context")
     fi
-  done < <(echo "$statuses" | jq -r '.statuses[]? | select(.context? | startswith("signoff")) | .context' 2>/dev/null)
+  done < <(echo "$statuses" | jq -r '.statuses[]? | select(.context? | startswith("signoff")) | .context' 2>/dev/null || echo "")
 
   # Generate status output for all contexts (required + actual)
   local all_results=()
@@ -460,8 +465,9 @@ cmd_status() {
     [[ "$context" == "signoff/"* ]] && display_name="${context#signoff/}"
     [[ "$context" == "signoff" ]] && display_name="signoff"
 
-    # Check if we have a status for this context - use safe array access
-    if [[ -n "${context_states[$context]:-}" && "${context_states[$context]:-}" == "success" ]]; then
+    # Check if we have a successful status for this context
+    # by looking for "context=success;" in our map
+    if [[ "$context_map" == *"${context}=success;"* ]]; then
       all_results+=("${STATUS_SUCCESS} $display_name")
     else
       all_results+=("${STATUS_FAILURE} $display_name")

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASH_VERSION=5
+FROM bash:${BASH_VERSION}
+
+# Install required packages
+RUN apk add --no-cache \
+    git \
+    bats \
+    jq \
+    curl
+
+# Configure Git for CI environment
+RUN git config --global user.name "CI Test User" && \
+    git config --global user.email "test@example.com" && \
+    git config --global init.defaultBranch main
+
+# Set working directory
+WORKDIR /app
+
+# Default command - use shell to expand the glob pattern
+CMD ["/bin/bash", "-c", "bats test/*.bats"]


### PR DESCRIPTION
* Can't use associative arrays
* Error handling in process substitution
* bin/ci covers Bash 3, 4, and 5

Fixes #5 