### PR TITLE
Use "tool" instead of "gem" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ eval "$(gh signoff completion)"
 
 
 ## License
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The tool is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
I just discovered `gh-signoff` and I think it's brilliant. Thank you for sharing it.

Going through the README, I noticed a minor language inconsistency. Here's a suggestion to use the word "tool" instead of "gem".

Thanks!