### PR TITLE
Support signing off on an explicit commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ gh extension install basecamp/gh-signoff
 
 # When your tests pass, sign off on your PR
 gh signoff
+
+# Or sign off on a specific commit
+gh signoff --sha abc123
 ```
 
 Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote whose single push URL matches its fetch URL, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
@@ -75,6 +78,13 @@ Check whether you've signed off on the current commit:
 
 ```bash
 gh signoff status
+✓ signoff
+```
+
+Check a specific commit:
+
+```bash
+gh signoff status --sha abc123
 ✓ signoff
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,21 @@ gh extension install basecamp/gh-signoff
 
 # When your tests pass, sign off on your PR
 gh signoff
-
-# Or sign off on a specific commit
-gh signoff --commit abc123
 ```
 
 Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote whose single push URL matches its fetch URL, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
+
+### Signing off on a specific commit
+
+`gh signoff` targets `HEAD`. To sign off on a different commit — handy with stacked or virtual branches (e.g. GitButler), where the commit under test isn't what's checked out:
+
+```bash
+gh signoff --commit abc1234
+gh signoff --commit HEAD~1 tests
+gh signoff status --commit abc1234
+```
+
+`--commit` takes anything `git rev-parse` resolves. The commit still has to be on a remote — a commit you haven't fetched can't be checked, so it needs `-f`, same as any other override.
 
 A branch checked out from a cross-repository pull request (`gh pr checkout` on a fork PR) tracks a bare URL rather than a named remote, so it has no tracking ref for either `@{push}` or `@{upstream}` to resolve. Signoff asks that repository directly instead — one `git ls-remote` for the tracked ref — and accepts HEAD when it's contained in the advertised tip. If that tip isn't already in your repository, or a push wouldn't provably land on the same URL, it refuses rather than guess.
 
@@ -84,7 +93,7 @@ gh signoff status
 Check a specific commit:
 
 ```bash
-gh signoff status --commit abc123
+gh signoff status --commit abc1234
 ✓ signoff
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gh extension install basecamp/gh-signoff
 gh signoff
 
 # Or sign off on a specific commit
-gh signoff --sha abc123
+gh signoff --commit abc123
 ```
 
 Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote whose single push URL matches its fetch URL, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
@@ -84,7 +84,7 @@ gh signoff status
 Check a specific commit:
 
 ```bash
-gh signoff status --sha abc123
+gh signoff status --commit abc123
 ✓ signoff
 ```
 

--- a/gh-signoff
+++ b/gh-signoff
@@ -45,9 +45,9 @@ fail() {
   exit 1
 }
 
-validate_sha() {
+validate_commit() {
   if [[ ! "$1" =~ ^[0-9a-fA-F]{4,40}$ ]]; then
-    fail "invalid sha: $1"
+    fail "invalid commit: $1"
   fi
 }
 
@@ -278,7 +278,7 @@ is_clean() {
 
 cmd_create() {
   local force=false
-  local sha=""
+  local commit=""
   local contexts=()
 
   # Process arguments
@@ -288,12 +288,12 @@ cmd_create() {
         force=true
         shift
         ;;
-      --sha)
+      --commit)
         if [[ -z "${2:-}" || "$2" == -* ]]; then
-          fail "option --sha requires an argument"
+          fail "option --commit requires an argument"
         fi
-        sha="$2"
-        validate_sha "$sha"
+        commit="$2"
+        validate_commit "$commit"
         shift 2
         ;;
 
@@ -308,7 +308,7 @@ cmd_create() {
     esac
   done
 
-  if [[ -z "$sha" ]] && ! $force && ! is_clean; then
+  if [[ -z "$commit" ]] && ! $force && ! is_clean; then
     fail "$UNCLEAN_REASON"
   fi
 
@@ -316,8 +316,8 @@ cmd_create() {
   user=$(git config user.name) || fail "failed to get git user name"
   [[ -z "$user" ]] && fail "git user.name is not set"
 
-  if [[ -z "$sha" ]]; then
-    sha=$(git rev-parse HEAD) || fail "failed to get current commit"
+  if [[ -z "$commit" ]]; then
+    commit=$(git rev-parse HEAD) || fail "failed to get current commit"
   fi
 
   # If no contexts specified, use default
@@ -335,27 +335,27 @@ cmd_create() {
       context_name="signoff/${context}"
     fi
 
-    debug "creating status for commit ${sha} by ${user} with context ${context_name}"
+    debug "creating status for commit ${commit} by ${user} with context ${context_name}"
 
     if gh api \
       --method POST \
-      "repos/:owner/:repo/statuses/${sha}" \
+      "repos/:owner/:repo/statuses/${commit}" \
       -f state=success \
       -f context="${context_name}" \
       -f "description=${user} signed off" >/dev/null; then
 
       # Build success message
       if [[ -z "$context" ]]; then
-        success_messages+=("${STATUS_SUCCESS} Signed off on ${sha}")
+        success_messages+=("${STATUS_SUCCESS} Signed off on ${commit}")
       else
-        success_messages+=("${STATUS_SUCCESS} Signed off on ${sha} for ${context}")
+        success_messages+=("${STATUS_SUCCESS} Signed off on ${commit} for ${context}")
       fi
     else
       success=false
       if [[ -z "$context" ]]; then
-        echo "${STATUS_FAILURE} Failed to sign off on ${sha}" >&2
+        echo "${STATUS_FAILURE} Failed to sign off on ${commit}" >&2
       else
-        echo "${STATUS_FAILURE} Failed to sign off on ${sha} for ${context}" >&2
+        echo "${STATUS_FAILURE} Failed to sign off on ${commit} for ${context}" >&2
       fi
     fi
   done
@@ -580,7 +580,7 @@ cmd_check() {
 
 cmd_status() {
   local branch=""
-  local sha=""
+  local commit=""
 
   # Process arguments with option handling
   while [[ $# -gt 0 ]]; do
@@ -592,12 +592,12 @@ cmd_status() {
         branch="$2"
         shift 2
         ;;
-      --sha)
+      --commit)
         if [[ -z "${2:-}" || "$2" == -* ]]; then
-          fail "option --sha requires an argument"
+          fail "option --commit requires an argument"
         fi
-        sha="$2"
-        validate_sha "$sha"
+        commit="$2"
+        validate_commit "$commit"
         shift 2
         ;;
       -*)
@@ -616,18 +616,18 @@ cmd_status() {
   fi
   [[ -z "$branch" ]] && fail "branch name cannot be empty"
 
-  # Get current SHA when one was not provided
-  if [[ -z "$sha" ]]; then
-    sha=$(git rev-parse HEAD) || fail "failed to get current commit"
+  # Default to the current commit
+  if [[ -z "$commit" ]]; then
+    commit=$(git rev-parse HEAD) || fail "failed to get current commit"
   fi
 
   # Get the signoff statuses on this commit as context/state pairs. A filter
   # error surfaces here rather than silently rendering every context as failed.
   local statuses
-  statuses=$(gh api "repos/:owner/:repo/commits/${sha}/status" \
+  statuses=$(gh api "repos/:owner/:repo/commits/${commit}/status" \
     --jq '.statuses[]? | select(.context? | startswith("signoff")) | [.context, .state] | @tsv' \
     2>/dev/null) || {
-    echo "${STATUS_FAILURE} Could not get status for commit ${sha}"
+    echo "${STATUS_FAILURE} Could not get status for commit ${commit}"
     exit 1
   }
   statuses=${statuses//$'\r'/}
@@ -711,7 +711,7 @@ _gh_signoff() {
     signoff)
       # Include dynamic contexts in top-level completion
       local contexts=$(_gh_signoff_contexts)
-      COMPREPLY=( $(compgen -W "create install uninstall check status version -f --sha --help $contexts" -- "$cur") )
+      COMPREPLY=( $(compgen -W "create install uninstall check status version -f --commit --help $contexts" -- "$cur") )
       return 0
       ;;
     -f)
@@ -727,11 +727,11 @@ _gh_signoff() {
       ;;
     create)
       local contexts=$(_gh_signoff_contexts)
-      COMPREPLY=( $(compgen -W "-f --sha $contexts" -- "$cur") )
+      COMPREPLY=( $(compgen -W "-f --commit $contexts" -- "$cur") )
       return 0
       ;;
     status)
-      COMPREPLY=( $(compgen -W "--branch --sha" -- "$cur") )
+      COMPREPLY=( $(compgen -W "--branch --commit" -- "$cur") )
       return 0
       ;;
     install|uninstall|check)
@@ -745,13 +745,13 @@ _gh_signoff() {
   if [[ $cur == --* ]]; then
     case "${COMP_WORDS[1]}" in
       create|status)
-        COMPREPLY=( $(compgen -W "--sha" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--commit" -- "$cur") )
         ;;
       install|uninstall|check)
         COMPREPLY=( $(compgen -W "--branch" -- "$cur") )
         ;;
       *)
-        COMPREPLY=( $(compgen -W "--sha --help" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--commit --help" -- "$cur") )
         ;;
     esac
     return 0
@@ -787,11 +787,11 @@ USAGE
   gh signoff [flags] [command] [options]
 
 COMMANDS
-  create (default) Sign off on the current commit or a specific commit SHA
+  create (default) Sign off on the current commit or a specific commit
   install          Install signoff requirement
   uninstall        Uninstall signoff requirement
   check            Check if signoff is required
-  status           Show signoff status for the current commit or a specific commit SHA
+  status           Show signoff status for the current commit or a specific commit
   version          Show gh-signoff version
   completion       Output shell completion code
 
@@ -800,19 +800,19 @@ FLAGS
 
 OPTIONS
   --branch <branch>  Branch to operate on (for install, uninstall, check, status)
-  --sha <sha>        Commit SHA to operate on (for create, status)
+  --commit <sha>     Commit to operate on (for create, status)
 
 EXAMPLES
-  gh signoff                         # Sign off on current commit
-  gh signoff --sha abc123            # Sign off on a specific commit
-  gh signoff create -f               # Force signoff
-  gh signoff create --sha abc123     # Sign off on a specific commit
-  gh signoff install                 # Require signoff on default branch
-  gh signoff install --branch other  # Require signoff on a specific branch
-  gh signoff check                   # Check if signoff is required
-  gh signoff check --branch other    # Check if signoff is required on branch
-  gh signoff status                  # Show completed/pending signoff status
-  gh signoff status --sha abc123     # Show status for a specific commit
+  gh signoff                           # Sign off on current commit
+  gh signoff --commit abc1234          # Sign off on a specific commit
+  gh signoff create -f                 # Force signoff
+  gh signoff create --commit abc1234   # Sign off on a specific commit
+  gh signoff install                   # Require signoff on default branch
+  gh signoff install --branch other    # Require signoff on a specific branch
+  gh signoff check                     # Check if signoff is required
+  gh signoff check --branch other      # Check if signoff is required on branch
+  gh signoff status                    # Show completed/pending signoff status
+  gh signoff status --commit abc1234   # Show status for a specific commit
 
 COMPLETION
   # Add to ~/.bashrc:
@@ -844,8 +844,8 @@ case "${1:-}" in
   "version")        reject_force; cmd_version ;;
   "completion")     reject_force; shift; cmd_completion "$@" ;;
   "-h" | "--help")  reject_force; cmd_help ;;
-  "--sha")
-    # An explicit sha with no command is a create
+  "--commit")
+    # An explicit commit with no command is a create
     cmd_create ${force:+-f} "$@"
     ;;
   -*)

--- a/gh-signoff
+++ b/gh-signoff
@@ -768,8 +768,21 @@ _gh_signoff_contexts() {
   echo "$contexts"
 }
 
+# The first word that is neither a global option nor its argument. -f and
+# --commit may precede the command, so COMP_WORDS[1] is not it.
+_gh_signoff_command() {
+  local i=1
+  while [[ $i -lt ${#COMP_WORDS[@]} ]]; do
+    case "${COMP_WORDS[$i]}" in
+      -f)       i=$((i+1)) ;;
+      --commit) i=$((i+2)) ;;
+      *)        echo "${COMP_WORDS[$i]}"; return ;;
+    esac
+  done
+}
+
 _gh_signoff() {
-  local cur prev
+  local cur prev command
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
@@ -780,12 +793,16 @@ _gh_signoff() {
       COMPREPLY=( $(compgen -W "create install uninstall check status version -f --commit --help $contexts" -- "$cur") )
       return 0
       ;;
+    --commit)
+      # A revision. Nothing worth guessing at.
+      return 0
+      ;;
     -f)
-      # A leading -f may be followed by the create command or a context;
-      # elsewhere only contexts remain
+      # A leading -f may be followed by the create command, --commit or a
+      # context; elsewhere only contexts remain
       local contexts=$(_gh_signoff_contexts)
       if [[ $COMP_CWORD -eq 2 ]]; then
-        COMPREPLY=( $(compgen -W "create $contexts" -- "$cur") )
+        COMPREPLY=( $(compgen -W "create --commit $contexts" -- "$cur") )
       else
         COMPREPLY=( $(compgen -W "$contexts" -- "$cur") )
       fi
@@ -807,28 +824,30 @@ _gh_signoff() {
       ;;
   esac
 
+  command=$(_gh_signoff_command)
+
   # If we are halfway through typing an option
   if [[ $cur == --* ]]; then
-    case "${COMP_WORDS[1]}" in
-      create|status)
-        COMPREPLY=( $(compgen -W "--commit" -- "$cur") )
-        ;;
+    case "$command" in
       install|uninstall|check)
         COMPREPLY=( $(compgen -W "--branch" -- "$cur") )
         ;;
+      status)
+        COMPREPLY=( $(compgen -W "--branch --commit" -- "$cur") )
+        ;;
       *)
-        COMPREPLY=( $(compgen -W "--commit --help" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--commit" -- "$cur") )
         ;;
     esac
     return 0
   fi
 
   # For partial signoffs, suggest context names
-  if [[ $COMP_CWORD -gt 1 && "${COMP_WORDS[1]}" != "install" &&
-        "${COMP_WORDS[1]}" != "uninstall" && "${COMP_WORDS[1]}" != "check" &&
-        "${COMP_WORDS[1]}" != "status" && "${COMP_WORDS[1]}" != "version" &&
-        "${COMP_WORDS[1]}" != "completion" && "${COMP_WORDS[1]}" != "--help" &&
-        "${COMP_WORDS[1]}" != "-h" ]]; then
+  if [[ $COMP_CWORD -gt 1 && "$command" != "install" &&
+        "$command" != "uninstall" && "$command" != "check" &&
+        "$command" != "status" && "$command" != "version" &&
+        "$command" != "completion" && "$command" != "--help" &&
+        "$command" != "-h" ]]; then
     local contexts=$(_gh_signoff_contexts)
     COMPREPLY=( $(compgen -W "$contexts" -- "$cur") )
     return 0

--- a/gh-signoff
+++ b/gh-signoff
@@ -272,6 +272,7 @@ is_clean() {
 
 cmd_create() {
   local force=false
+  local sha=""
   local contexts=()
 
   # Process arguments
@@ -280,6 +281,13 @@ cmd_create() {
       -f)
         force=true
         shift
+        ;;
+      --sha)
+        if [[ -z "${2:-}" || "$2" == -* ]]; then
+          fail "option --sha requires an argument"
+        fi
+        sha="$2"
+        shift 2
         ;;
 
       -*)
@@ -293,7 +301,7 @@ cmd_create() {
     esac
   done
 
-  if ! $force && ! is_clean; then
+  if [[ -z "$sha" ]] && ! $force && ! is_clean; then
     fail "$UNCLEAN_REASON"
   fi
 
@@ -301,8 +309,9 @@ cmd_create() {
   user=$(git config user.name) || fail "failed to get git user name"
   [[ -z "$user" ]] && fail "git user.name is not set"
 
-  local sha
-  sha=$(git rev-parse HEAD) || fail "failed to get current commit"
+  if [[ -z "$sha" ]]; then
+    sha=$(git rev-parse HEAD) || fail "failed to get current commit"
+  fi
 
   # If no contexts specified, use default
   if [ ${#contexts[@]} -eq 0 ]; then
@@ -576,6 +585,13 @@ cmd_status() {
         branch="$2"
         shift 2
         ;;
+      --sha)
+        if [[ -z "${2:-}" || "$2" == -* ]]; then
+          fail "option --sha requires an argument"
+        fi
+        sha="$2"
+        shift 2
+        ;;
       -*)
         fail "unknown option: $1"
         ;;
@@ -592,8 +608,10 @@ cmd_status() {
   fi
   [[ -z "$branch" ]] && fail "branch name cannot be empty"
 
-  # Get current SHA
-  sha=$(git rev-parse HEAD) || fail "failed to get current commit"
+  # Get current SHA when one was not provided
+  if [[ -z "$sha" ]]; then
+    sha=$(git rev-parse HEAD) || fail "failed to get current commit"
+  fi
 
   # Get the signoff statuses on this commit as context/state pairs. A filter
   # error surfaces here rather than silently rendering every context as failed.
@@ -685,7 +703,7 @@ _gh_signoff() {
     signoff)
       # Include dynamic contexts in top-level completion
       local contexts=$(_gh_signoff_contexts)
-      COMPREPLY=( $(compgen -W "create install uninstall check status version -f --help $contexts" -- "$cur") )
+      COMPREPLY=( $(compgen -W "create install uninstall check status version -f --sha --help $contexts" -- "$cur") )
       return 0
       ;;
     -f)
@@ -701,7 +719,11 @@ _gh_signoff() {
       ;;
     create)
       local contexts=$(_gh_signoff_contexts)
-      COMPREPLY=( $(compgen -W "$contexts" -- "$cur") )
+      COMPREPLY=( $(compgen -W "--sha $contexts" -- "$cur") )
+      return 0
+      ;;
+    status)
+      COMPREPLY=( $(compgen -W "--branch --sha" -- "$cur") )
       return 0
       ;;
     install|uninstall|check)
@@ -709,15 +731,11 @@ _gh_signoff() {
       COMPREPLY=( $(compgen -W "--branch $contexts" -- "$cur") )
       return 0
       ;;
-    status)
-      COMPREPLY=( $(compgen -W "--branch" -- "$cur") )
-      return 0
-      ;;
   esac
 
   # If we are halfway through typing an option
   if [[ $cur == --* ]]; then
-    COMPREPLY=( $(compgen -W "--branch" -- "$cur") )
+    COMPREPLY=( $(compgen -W "--branch --sha" -- "$cur") )
     return 0
   fi
 
@@ -751,11 +769,11 @@ USAGE
   gh signoff [flags] [command] [options]
 
 COMMANDS
-  create (default) Sign off on the current commit
+  create (default) Sign off on the current commit or a specific commit SHA
   install          Install signoff requirement
   uninstall        Uninstall signoff requirement
   check            Check if signoff is required
-  status           Show signoff status for the current commit
+  status           Show signoff status for the current commit or a specific commit SHA
   version          Show gh-signoff version
   completion       Output shell completion code
 
@@ -763,16 +781,20 @@ FLAGS
   -f  Force sign off (ignore uncommitted/unpushed changes)
 
 OPTIONS
-  --branch <branch>  Branch to operate on (for install, uninstall, check)
+  --branch <branch>  Branch to operate on (for install, uninstall, check, status)
+  --sha <sha>        Commit SHA to operate on (for create, status)
 
 EXAMPLES
   gh signoff                         # Sign off on current commit
+  gh signoff --sha abc123            # Sign off on a specific commit
   gh signoff create -f               # Force signoff
+  gh signoff create --sha abc123     # Sign off on a specific commit
   gh signoff install                 # Require signoff on default branch
   gh signoff install --branch other  # Require signoff on a specific branch
   gh signoff check                   # Check if signoff is required
   gh signoff check --branch other    # Check if signoff is required on branch
   gh signoff status                  # Show completed/pending signoff status
+  gh signoff status --sha abc123     # Show status for a specific commit
 
 COMPLETION
   # Add to ~/.bashrc:
@@ -804,6 +826,10 @@ case "${1:-}" in
   "version")        reject_force; cmd_version ;;
   "completion")     reject_force; shift; cmd_completion "$@" ;;
   "-h" | "--help")  reject_force; cmd_help ;;
+  "--sha")
+    # An explicit sha with no command is a create
+    cmd_create ${force:+-f} "$@"
+    ;;
   -*)
     # Unknown option
     cmd_help; exit 1

--- a/gh-signoff
+++ b/gh-signoff
@@ -422,7 +422,7 @@ cmd_install() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --branch)
-        if [[ -z "$2" || "$2" == -* ]]; then
+        if [[ -z "${2:-}" || "$2" == -* ]]; then
           fail "option --branch requires an argument"
         fi
         branch="$2"
@@ -503,7 +503,7 @@ cmd_uninstall() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --branch)
-        if [[ -z "$2" || "$2" == -* ]]; then
+        if [[ -z "${2:-}" || "$2" == -* ]]; then
           fail "option --branch requires an argument"
         fi
         branch="$2"
@@ -567,7 +567,7 @@ cmd_check() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --branch)
-        if [[ -z "$2" || "$2" == -* ]]; then
+        if [[ -z "${2:-}" || "$2" == -* ]]; then
           fail "option --branch requires an argument"
         fi
         branch="$2"
@@ -649,7 +649,7 @@ cmd_status() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --branch)
-        if [[ -z "$2" || "$2" == -* ]]; then
+        if [[ -z "${2:-}" || "$2" == -* ]]; then
           fail "option --branch requires an argument"
         fi
         branch="$2"

--- a/gh-signoff
+++ b/gh-signoff
@@ -45,6 +45,12 @@ fail() {
   exit 1
 }
 
+validate_sha() {
+  if [[ ! "$1" =~ ^[0-9a-fA-F]{4,40}$ ]]; then
+    fail "invalid sha: $1"
+  fi
+}
+
 # Get default branch with caching
 #
 # Two conventions apply to every gh call below. Filtering uses gh's built-in
@@ -287,6 +293,7 @@ cmd_create() {
           fail "option --sha requires an argument"
         fi
         sha="$2"
+        validate_sha "$sha"
         shift 2
         ;;
 
@@ -590,6 +597,7 @@ cmd_status() {
           fail "option --sha requires an argument"
         fi
         sha="$2"
+        validate_sha "$sha"
         shift 2
         ;;
       -*)
@@ -719,7 +727,7 @@ _gh_signoff() {
       ;;
     create)
       local contexts=$(_gh_signoff_contexts)
-      COMPREPLY=( $(compgen -W "--sha $contexts" -- "$cur") )
+      COMPREPLY=( $(compgen -W "-f --sha $contexts" -- "$cur") )
       return 0
       ;;
     status)
@@ -735,7 +743,17 @@ _gh_signoff() {
 
   # If we are halfway through typing an option
   if [[ $cur == --* ]]; then
-    COMPREPLY=( $(compgen -W "--branch --sha" -- "$cur") )
+    case "${COMP_WORDS[1]}" in
+      create|status)
+        COMPREPLY=( $(compgen -W "--sha" -- "$cur") )
+        ;;
+      install|uninstall|check)
+        COMPREPLY=( $(compgen -W "--branch" -- "$cur") )
+        ;;
+      *)
+        COMPREPLY=( $(compgen -W "--sha --help" -- "$cur") )
+        ;;
+    esac
     return 0
   fi
 

--- a/gh-signoff
+++ b/gh-signoff
@@ -780,10 +780,13 @@ _gh_signoff_contexts() {
 }
 
 # The first word that is neither a global option nor its argument. -f and
-# --commit may precede the command, so COMP_WORDS[1] is not it.
+# --commit may precede the command, so COMP_WORDS[1] is not it. Stops short of
+# the word being completed: that one is what the user is still typing, not a
+# command they have settled on, and echoing it back would suppress the very
+# list they are typing towards. Empty means the cursor is at the command.
 _gh_signoff_command() {
   local i=1
-  while [[ $i -lt ${#COMP_WORDS[@]} ]]; do
+  while [[ $i -lt $COMP_CWORD ]]; do
     case "${COMP_WORDS[$i]}" in
       -f)       i=$((i+1)) ;;
       --commit) i=$((i+2)) ;;
@@ -850,6 +853,15 @@ _gh_signoff() {
         COMPREPLY=( $(compgen -W "--commit" -- "$cur") )
         ;;
     esac
+    return 0
+  fi
+
+  # No command yet, so the cursor is where one goes: offer the same list as
+  # directly after `signoff`, which a leading -f or --commit would otherwise
+  # push out of reach
+  if [[ -z "$command" ]]; then
+    local contexts=$(_gh_signoff_contexts)
+    COMPREPLY=( $(compgen -W "create install uninstall check status version -f --commit --help $contexts" -- "$cur") )
     return 0
   fi
 

--- a/gh-signoff
+++ b/gh-signoff
@@ -3,7 +3,7 @@ set -euo pipefail
 # set -x # Keep this commented out unless actively debugging
 
 DEBUG=${SIGNOFF_DEBUG:-}
-readonly VERSION="0.2.2"
+readonly VERSION="0.3.0"
 
 # Status symbols for consistent display - export them for both script and tests
 export STATUS_SUCCESS="✓"

--- a/gh-signoff
+++ b/gh-signoff
@@ -34,6 +34,10 @@ UNCLEAN_REASON=""
 # Tip SHA url_remote_tip proved, for is_clean to check HEAD against
 URL_REMOTE_TIP=""
 
+# Results of the last resolve_commit call
+RESOLVED_COMMIT=""
+RESOLVED_COMMIT_IS_LOCAL=true
+
 debug() {
   if [[ -n "$DEBUG" ]]; then
     echo "Debug: $*" >&2
@@ -45,10 +49,39 @@ fail() {
   exit 1
 }
 
-validate_commit() {
-  if [[ ! "$1" =~ ^[0-9a-fA-F]{4,40}$ ]]; then
-    fail "invalid commit: $1"
+# Expand a revision — a short sha, a tag, a branch, HEAD~1 — to the full sha
+# of the commit it names. Reports via RESOLVED_COMMIT and, since a sha we
+# have no object for can't be checked against a remote, RESOLVED_COMMIT_IS_LOCAL.
+resolve_commit() {
+  local rev="$1"
+
+  if [[ -z "$rev" || "$rev" == -* ]]; then
+    fail "option --commit requires an argument"
   fi
+
+  RESOLVED_COMMIT=$(git rev-parse --verify --quiet "${rev}^{commit}" 2>/dev/null) || RESOLVED_COMMIT=""
+
+  if [[ -n "$RESOLVED_COMMIT" ]]; then
+    RESOLVED_COMMIT_IS_LOCAL=true
+    return
+  fi
+
+  # We have the object but it doesn't peel to a commit: a tree or a blob
+  if git cat-file -e "$rev" 2>/dev/null; then
+    fail "not a commit: $rev"
+  fi
+
+  # Unknown to git. A full sha may still name a commit we haven't fetched;
+  # anything shorter or non-hex is a typo, not a revision.
+  [[ "$rev" =~ ^[0-9a-f]{40}$ ]] || fail "invalid commit: $rev"
+  RESOLVED_COMMIT="$rev"
+  RESOLVED_COMMIT_IS_LOCAL=false
+}
+
+# Is the commit on a remote we know about? Remote-tracking refs are only as
+# fresh as the last fetch, so this is a local proxy; -f overrides.
+commit_is_on_a_remote() {
+  [[ -n "$(git branch -r --contains "$1" 2>/dev/null)" ]]
 }
 
 # Get default branch with caching
@@ -278,7 +311,7 @@ is_clean() {
 
 cmd_create() {
   local force=false
-  local commit=""
+  local commit="" commit_is_local=true
   local contexts=()
 
   # Process arguments
@@ -289,11 +322,9 @@ cmd_create() {
         shift
         ;;
       --commit)
-        if [[ -z "${2:-}" || "$2" == -* ]]; then
-          fail "option --commit requires an argument"
-        fi
-        commit="$2"
-        validate_commit "$commit"
+        resolve_commit "${2:-}"
+        commit="$RESOLVED_COMMIT"
+        commit_is_local=$RESOLVED_COMMIT_IS_LOCAL
         shift 2
         ;;
 
@@ -308,8 +339,16 @@ cmd_create() {
     esac
   done
 
-  if [[ -z "$commit" ]] && ! $force && ! is_clean; then
-    fail "$UNCLEAN_REASON"
+  # Signing off on a named commit says nothing about the worktree, but the
+  # commit itself still has to have made it to a remote
+  if ! $force; then
+    if [[ -z "$commit" ]]; then
+      is_clean || fail "$UNCLEAN_REASON"
+    elif ! $commit_is_local; then
+      fail "cannot verify ${commit} is on a remote (not a local object; -f to override)"
+    elif ! commit_is_on_a_remote "$commit"; then
+      fail "commit ${commit} is not on any remote (-f to override)"
+    fi
   fi
 
   local user
@@ -593,11 +632,8 @@ cmd_status() {
         shift 2
         ;;
       --commit)
-        if [[ -z "${2:-}" || "$2" == -* ]]; then
-          fail "option --commit requires an argument"
-        fi
-        commit="$2"
-        validate_commit "$commit"
+        resolve_commit "${2:-}"
+        commit="$RESOLVED_COMMIT"
         shift 2
         ;;
       -*)

--- a/gh-signoff
+++ b/gh-signoff
@@ -49,6 +49,12 @@ fail() {
   exit 1
 }
 
+reject_extra_args() {
+  if [[ $# -gt 0 ]]; then
+    fail "unexpected argument: $1"
+  fi
+}
+
 # Expand a revision — a short sha, a tag, a branch, HEAD~1 — to the full sha
 # of the commit it names. Reports via RESOLVED_COMMIT and, since a sha we
 # have no object for can't be checked against a remote, RESOLVED_COMMIT_IS_LOCAL.
@@ -422,6 +428,12 @@ cmd_install() {
         branch="$2"
         shift 2
         ;;
+      -f)
+        fail "-f is only valid for create"
+        ;;
+      --commit)
+        fail "--commit is only valid for create and status"
+        ;;
       -*)
         fail "unknown option: $1"
         ;;
@@ -497,6 +509,12 @@ cmd_uninstall() {
         branch="$2"
         shift 2
         ;;
+      -f)
+        fail "-f is only valid for create"
+        ;;
+      --commit)
+        fail "--commit is only valid for create and status"
+        ;;
       -*)
         fail "unknown option: $1"
         ;;
@@ -554,6 +572,12 @@ cmd_check() {
         fi
         branch="$2"
         shift 2
+        ;;
+      -f)
+        fail "-f is only valid for create"
+        ;;
+      --commit)
+        fail "--commit is only valid for create and status"
         ;;
       -*)
         fail "unknown option: $1"
@@ -635,6 +659,9 @@ cmd_status() {
         resolve_commit "${2:-}"
         commit="$RESOLVED_COMMIT"
         shift 2
+        ;;
+      -f)
+        fail "-f is only valid for create"
         ;;
       -*)
         fail "unknown option: $1"
@@ -725,9 +752,12 @@ cmd_status() {
 cmd_completion() {
   # Check if --contexts flag is passed
   if [[ "${1:-}" == "--contexts" ]]; then
+    shift
+    reject_extra_args "$@"
     get_signoff_contexts
     return
   fi
+  reject_extra_args "$@"
 
   cat <<'EOF'
 # bash completion for gh signoff
@@ -856,13 +886,30 @@ COMPLETION
 EOF
 }
 
-# A leading -f applies to create (explicit, implicit, or contextual)
-# and is rejected for every other command
+# A leading -f applies to create (explicit, implicit, or contextual); a leading
+# --commit to create and status. Both are rejected for every other command.
+#
+# The revision stays raw here: resolving it before the command is known would
+# report `gh signoff --commit nope install` as a bad revision, when what's
+# actually wrong is that install takes no --commit at all.
 force=""
-if [[ "${1:-}" == "-f" ]]; then
-  force="-f"
-  shift
-fi
+commit_opt=()
+while :; do
+  case "${1:-}" in
+    -f)
+      force="-f"
+      shift
+      ;;
+    --commit)
+      [[ -n "${2:-}" && "$2" != -* ]] || fail "option --commit requires an argument"
+      commit_opt=(--commit "$2")
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 reject_force() {
   if [[ -n "$force" ]]; then
@@ -870,26 +917,30 @@ reject_force() {
   fi
 }
 
+reject_commit() {
+  if [[ ${#commit_opt[@]} -gt 0 ]]; then
+    fail "--commit is only valid for create and status"
+  fi
+}
+
+# ${commit_opt[@]+"${commit_opt[@]}"} is the Bash 3 set -u safe expansion of a
+# possibly-empty array. ${commit_opt:+...} would word-split the revision.
 case "${1:-}" in
-  "")               cmd_create ${force:+-f} ;;
-  "create")         shift; cmd_create ${force:+-f} "$@" ;;
-  "install")        reject_force; shift; cmd_install "$@" ;;
-  "uninstall")      reject_force; shift; cmd_uninstall "$@" ;;
-  "check")          reject_force; shift; cmd_check "$@" ;;
-  "status")         reject_force; shift; cmd_status "$@" ;;
-  "version")        reject_force; cmd_version ;;
-  "completion")     reject_force; shift; cmd_completion "$@" ;;
-  "-h" | "--help")  reject_force; cmd_help ;;
-  "--commit")
-    # An explicit commit with no command is a create
-    cmd_create ${force:+-f} "$@"
-    ;;
+  "")               cmd_create ${force:+-f} ${commit_opt[@]+"${commit_opt[@]}"} ;;
+  "create")         shift; cmd_create ${force:+-f} ${commit_opt[@]+"${commit_opt[@]}"} "$@" ;;
+  "install")        reject_force; reject_commit; shift; cmd_install "$@" ;;
+  "uninstall")      reject_force; reject_commit; shift; cmd_uninstall "$@" ;;
+  "check")          reject_force; reject_commit; shift; cmd_check "$@" ;;
+  "status")         reject_force; shift; cmd_status ${commit_opt[@]+"${commit_opt[@]}"} "$@" ;;
+  "version")        reject_force; reject_commit; reject_extra_args "${@:2}"; cmd_version ;;
+  "completion")     reject_force; reject_commit; shift; cmd_completion "$@" ;;
+  "-h" | "--help")  reject_force; reject_commit; reject_extra_args "${@:2}"; cmd_help ;;
   -*)
     # Unknown option
     cmd_help; exit 1
     ;;
   *)
     # Treat as partial signoff context(s)
-    cmd_create ${force:+-f} "$@"
+    cmd_create ${force:+-f} ${commit_opt[@]+"${commit_opt[@]}"} "$@"
     ;;
 esac

--- a/gh-signoff
+++ b/gh-signoff
@@ -87,7 +87,18 @@ resolve_commit() {
 # Is the commit on a remote we know about? Remote-tracking refs are only as
 # fresh as the last fetch, so this is a local proxy; -f overrides.
 commit_is_on_a_remote() {
-  [[ -n "$(git branch -r --contains "$1" 2>/dev/null)" ]]
+  if [[ -n "$(git branch -r --contains "$1" 2>/dev/null)" ]]; then
+    return 0
+  fi
+
+  # A branch checked out from a fork pull request tracks a bare URL, which has
+  # no remote-tracking refs for `git branch -r` to search at all. Ask that
+  # remote for its tip the way is_clean does, and reuse the same inference: a
+  # commit contained in the tip is on that remote too. Without this,
+  # `gh signoff --commit HEAD` would refuse the very commit plain
+  # `gh signoff` just proved was published.
+  url_remote_tip || return 1
+  git merge-base --is-ancestor "$1" "$URL_REMOTE_TIP" 2>/dev/null
 }
 
 # Get default branch with caching

--- a/gh-signoff
+++ b/gh-signoff
@@ -885,13 +885,14 @@ FLAGS
 
 OPTIONS
   --branch <branch>  Branch to operate on (for install, uninstall, check, status)
-  --commit <sha>     Commit to operate on (for create, status)
+  --commit <sha>     Commit to sign off on (for create, status). Any revision
+                     git resolves; must be on a remote unless forced with -f
 
 EXAMPLES
   gh signoff                           # Sign off on current commit
   gh signoff --commit abc1234          # Sign off on a specific commit
+  gh signoff --commit HEAD~1 tests     # Partial signoff on a specific commit
   gh signoff create -f                 # Force signoff
-  gh signoff create --commit abc1234   # Sign off on a specific commit
   gh signoff install                   # Require signoff on default branch
   gh signoff install --branch other    # Require signoff on a specific branch
   gh signoff check                     # Check if signoff is required

--- a/test/mocks/gh
+++ b/test/mocks/gh
@@ -113,8 +113,8 @@ if [[ "$api_path" == "repos/:owner/:repo" && "$jq_filter" == ".default_branch" ]
 # Commit Status Call (GET)
 elif [[ "$api_method" == "GET" && "$api_path" == *"commits/"*"/status"* ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched GET Commit Status" >&2
-  if [[ -n "${MOCK_EXPECT_STATUS_SHA:-}" && "$api_path" != *"${MOCK_EXPECT_STATUS_SHA}"* ]]; then
-    echo "Expected commit status SHA ${MOCK_EXPECT_STATUS_SHA}, got path ${api_path}" >&2
+  if [[ -n "${MOCK_EXPECT_COMMIT:-}" && "$api_path" != *"${MOCK_EXPECT_COMMIT}"* ]]; then
+    echo "Expected commit status ${MOCK_EXPECT_COMMIT}, got path ${api_path}" >&2
     exit 99
   fi
   if [[ "$MOCK_COMMIT_STATUS_EXIT" -eq 0 ]]; then
@@ -137,8 +137,8 @@ elif [[ "$api_method" == "GET" && "$api_path" == *"branches/"*"/protection"* ]];
 # Create Status Call (POST)
 elif [[ "$api_method" == "POST" && "$api_path" == *"statuses/"* ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched POST Commit Status" >&2
-  if [[ -n "${MOCK_EXPECT_STATUS_SHA:-}" && "$api_path" != *"${MOCK_EXPECT_STATUS_SHA}"* ]]; then
-    echo "Expected status SHA ${MOCK_EXPECT_STATUS_SHA}, got path ${api_path}" >&2
+  if [[ -n "${MOCK_EXPECT_COMMIT:-}" && "$api_path" != *"${MOCK_EXPECT_COMMIT}"* ]]; then
+    echo "Expected status commit ${MOCK_EXPECT_COMMIT}, got path ${api_path}" >&2
     exit 99
   fi
   # POST usually doesn't output significant JSON on success in this script's usage

--- a/test/mocks/gh
+++ b/test/mocks/gh
@@ -113,6 +113,10 @@ if [[ "$api_path" == "repos/:owner/:repo" && "$jq_filter" == ".default_branch" ]
 # Commit Status Call (GET)
 elif [[ "$api_method" == "GET" && "$api_path" == *"commits/"*"/status"* ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched GET Commit Status" >&2
+  if [[ -n "${MOCK_EXPECT_STATUS_SHA:-}" && "$api_path" != *"${MOCK_EXPECT_STATUS_SHA}"* ]]; then
+    echo "Expected commit status SHA ${MOCK_EXPECT_STATUS_SHA}, got path ${api_path}" >&2
+    exit 99
+  fi
   if [[ "$MOCK_COMMIT_STATUS_EXIT" -eq 0 ]]; then
     emit "$MOCK_COMMIT_STATUS_JSON"
   else
@@ -133,6 +137,10 @@ elif [[ "$api_method" == "GET" && "$api_path" == *"branches/"*"/protection"* ]];
 # Create Status Call (POST)
 elif [[ "$api_method" == "POST" && "$api_path" == *"statuses/"* ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched POST Commit Status" >&2
+  if [[ -n "${MOCK_EXPECT_STATUS_SHA:-}" && "$api_path" != *"${MOCK_EXPECT_STATUS_SHA}"* ]]; then
+    echo "Expected status SHA ${MOCK_EXPECT_STATUS_SHA}, got path ${api_path}" >&2
+    exit 99
+  fi
   # POST usually doesn't output significant JSON on success in this script's usage
   exit "$MOCK_POST_STATUS_EXIT"
 

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -841,6 +841,15 @@ complete_words() {
   _gh_signoff
 }
 
+# As complete_words, but the last argument is a partially typed word
+complete_prefix() {
+  eval "$(gh-signoff completion)"
+  COMP_WORDS=("$@")
+  COMP_CWORD=$(($# - 1))
+  COMPREPLY=()
+  _gh_signoff
+}
+
 @test "completion after leading -f offers create plus contexts" {
   export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
   export MOCK_BRANCH_PROTECTION_EXIT=0
@@ -860,6 +869,46 @@ complete_words() {
   [[ " ${COMPREPLY[*]-} " == *" linux "* ]] || return 1
   [[ ! " ${COMPREPLY[*]-} " == *" create "* ]] || return 1
   [[ ! " ${COMPREPLY[*]-} " == *" --branch "* ]] || return 1
+}
+
+@test "completion after leading -f offers --commit" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_words gh-signoff -f
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
+}
+
+@test "completion after create offers -f and --commit" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_words gh-signoff create
+  [[ " ${COMPREPLY[*]-} " == *" -f "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" linux "* ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
+}
+
+@test "completion after --commit suggests nothing" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_words gh-signoff --commit
+  [[ ${#COMPREPLY[@]} -eq 0 ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
+}
+
+@test "completion finds the command past a leading --commit" {
+  # COMP_WORDS[1] here is --commit, not the command. Reading it directly would
+  # offer create's options in the middle of a status invocation.
+  complete_prefix gh-signoff --commit HEAD status --branch main --
+  [[ " ${COMPREPLY[*]-} " == *" --branch "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
 }
 
 @test "completion after trailing -f offers contexts without create" {

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -129,6 +129,27 @@ checkout_fork_pull_request() {
   [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
+@test "create signs off on specified sha" {
+  export MOCK_EXPECT_STATUS_SHA=abc123
+  run -0 gh-signoff create --sha abc123
+  [[ "$output" == *"Signed off on abc123"* ]]
+  unset MOCK_EXPECT_STATUS_SHA
+}
+
+@test "direct signoff signs off on specified sha" {
+  export MOCK_EXPECT_STATUS_SHA=def456
+  run -0 gh-signoff --sha def456
+  [[ "$output" == *"Signed off on def456"* ]]
+  unset MOCK_EXPECT_STATUS_SHA
+}
+
+@test "direct partial signoff signs off on specified sha" {
+  export MOCK_EXPECT_STATUS_SHA=def456
+  run -0 gh-signoff --sha def456 linux
+  [[ "$output" == *"Signed off on def456 for linux"* ]]
+  unset MOCK_EXPECT_STATUS_SHA
+}
+
 @test "check shows status for protected branch" {
   # Simulate protection requiring default signoff
   export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff"]}}'
@@ -258,6 +279,20 @@ checkout_fork_pull_request() {
 
   run -0 gh-signoff status
   [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]] || return 1
+}
+
+@test "status checks specified sha" {
+  # Mock: Protection requires 'signoff', Commit status has successful 'signoff'
+  export MOCK_EXPECT_STATUS_SHA=abc123
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+  export MOCK_COMMIT_STATUS_JSON='{"statuses":[{"context":"signoff","state":"success","description":"Test User signed off"}]}'
+  export MOCK_COMMIT_STATUS_EXIT=0
+
+  run -0 gh-signoff status --sha abc123
+  [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]]
+
+  unset MOCK_EXPECT_STATUS_SHA MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
 }
 
 @test "status shows missing default signoff" {

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -927,6 +927,23 @@ complete_prefix() {
   [[ ${#COMPREPLY[@]} -eq 0 ]] || return 1
 }
 
+@test "completion offers commands at the command position after a leading --commit" {
+  # The word under the cursor is what the user is typing, not a chosen command.
+  # Treating it as one skipped the command list, so `--commit HEAD st<TAB>`
+  # never offered status even though the dispatcher accepts it there.
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_prefix gh-signoff --commit HEAD st
+  [[ " ${COMPREPLY[*]-} " == *" status "* ]] || return 1
+
+  # Nothing typed yet: both commands and contexts are reachable
+  complete_words gh-signoff --commit HEAD
+  [[ " ${COMPREPLY[*]-} " == *" status "* ]] || return 1
+  [[ " ${COMPREPLY[*]-} " == *" create "* ]] || return 1
+  [[ " ${COMPREPLY[*]-} " == *" linux "* ]] || return 1
+}
+
 @test "completion finds the command past a leading --commit" {
   # COMP_WORDS[1] here is --commit, not the command. Reading it directly would
   # offer create's options in the middle of a status invocation.

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -129,30 +129,30 @@ checkout_fork_pull_request() {
   [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
-@test "create signs off on specified sha" {
-  export MOCK_EXPECT_STATUS_SHA=abc123
-  run -0 gh-signoff create --sha abc123
+@test "create signs off on specified commit" {
+  export MOCK_EXPECT_COMMIT=abc123
+  run -0 gh-signoff create --commit abc123
   [[ "$output" == *"Signed off on abc123"* ]]
-  unset MOCK_EXPECT_STATUS_SHA
+  unset MOCK_EXPECT_COMMIT
 }
 
-@test "create rejects invalid sha" {
-  run -1 gh-signoff create --sha 'abc/status'
-  [[ "$output" == *"invalid sha: abc/status"* ]]
+@test "create rejects invalid commit" {
+  run -1 gh-signoff create --commit 'abc/status'
+  [[ "$output" == *"invalid commit: abc/status"* ]]
 }
 
-@test "direct signoff signs off on specified sha" {
-  export MOCK_EXPECT_STATUS_SHA=def456
-  run -0 gh-signoff --sha def456
+@test "direct signoff signs off on specified commit" {
+  export MOCK_EXPECT_COMMIT=def456
+  run -0 gh-signoff --commit def456
   [[ "$output" == *"Signed off on def456"* ]]
-  unset MOCK_EXPECT_STATUS_SHA
+  unset MOCK_EXPECT_COMMIT
 }
 
-@test "direct partial signoff signs off on specified sha" {
-  export MOCK_EXPECT_STATUS_SHA=def456
-  run -0 gh-signoff --sha def456 linux
+@test "direct partial signoff signs off on specified commit" {
+  export MOCK_EXPECT_COMMIT=def456
+  run -0 gh-signoff --commit def456 linux
   [[ "$output" == *"Signed off on def456 for linux"* ]]
-  unset MOCK_EXPECT_STATUS_SHA
+  unset MOCK_EXPECT_COMMIT
 }
 
 @test "check shows status for protected branch" {
@@ -286,18 +286,18 @@ checkout_fork_pull_request() {
   [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]] || return 1
 }
 
-@test "status checks specified sha" {
+@test "status checks specified commit" {
   # Mock: Protection requires 'signoff', Commit status has successful 'signoff'
-  export MOCK_EXPECT_STATUS_SHA=abc123
+  export MOCK_EXPECT_COMMIT=abc123
   export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff"]}}'
   export MOCK_BRANCH_PROTECTION_EXIT=0
   export MOCK_COMMIT_STATUS_JSON='{"statuses":[{"context":"signoff","state":"success","description":"Test User signed off"}]}'
   export MOCK_COMMIT_STATUS_EXIT=0
 
-  run -0 gh-signoff status --sha abc123
+  run -0 gh-signoff status --commit abc123
   [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]]
 
-  unset MOCK_EXPECT_STATUS_SHA MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
+  unset MOCK_EXPECT_COMMIT MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
 }
 
 @test "status shows missing default signoff" {

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -112,6 +112,16 @@ checkout_fork_pull_request() {
   track_url_remote "$TEST_DIR/fork.git" refs/heads/their-branch
 }
 
+# A nested repository with two commits, both on origin, so that HEAD and HEAD~1
+# each satisfy the --commit remote check
+make_pushed_repo() {
+  make_nested_repo
+  add_bare_remote
+  git commit --no-gpg-sign --allow-empty -m "Second commit" >/dev/null
+  git push -q origin HEAD:main
+  git branch -q --set-upstream-to=origin/main
+}
+
 # Basic command tests
 @test "shows help with -h" {
   run -0 gh-signoff -h
@@ -129,30 +139,111 @@ checkout_fork_pull_request() {
   [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
-@test "create signs off on specified commit" {
-  export MOCK_EXPECT_COMMIT=abc123
-  run -0 gh-signoff create --commit abc123
-  [[ "$output" == *"Signed off on abc123"* ]]
-  unset MOCK_EXPECT_COMMIT
+@test "create signs off on the commit named by --commit" {
+  make_pushed_repo
+  sha=$(git rev-parse HEAD)
+  export MOCK_EXPECT_COMMIT="$sha"
+
+  run -0 gh-signoff create --commit "$sha"
+  [[ "$output" == *"Signed off on $sha"* ]]
 }
 
-@test "create rejects invalid commit" {
+@test "direct signoff signs off on the commit named by --commit" {
+  make_pushed_repo
+  sha=$(git rev-parse HEAD)
+  export MOCK_EXPECT_COMMIT="$sha"
+
+  run -0 gh-signoff --commit "$sha"
+  [[ "$output" == *"Signed off on $sha"* ]]
+}
+
+@test "direct partial signoff signs off on the commit named by --commit" {
+  make_pushed_repo
+  sha=$(git rev-parse HEAD)
+  export MOCK_EXPECT_COMMIT="$sha"
+
+  run -0 gh-signoff --commit "$sha" linux
+  [[ "$output" == *"Signed off on $sha for linux"* ]]
+}
+
+@test "--commit takes any revision git resolves" {
+  make_pushed_repo
+  sha=$(git rev-parse HEAD~1)
+  export MOCK_EXPECT_COMMIT="$sha"
+
+  run -0 gh-signoff --commit HEAD~1
+  [[ "$output" == *"Signed off on $sha"* ]]
+}
+
+@test "--commit expands a short sha to the full 40 hex" {
+  make_pushed_repo
+  sha=$(git rev-parse HEAD)
+  export MOCK_EXPECT_COMMIT="$sha"
+
+  run -0 gh-signoff --commit "${sha:0:8}"
+  [[ "$output" == *"Signed off on $sha"* ]]
+}
+
+@test "--commit rejects a revision git cannot resolve" {
   run -1 gh-signoff create --commit 'abc/status'
   [[ "$output" == *"invalid commit: abc/status"* ]]
 }
 
-@test "direct signoff signs off on specified commit" {
-  export MOCK_EXPECT_COMMIT=def456
-  run -0 gh-signoff --commit def456
-  [[ "$output" == *"Signed off on def456"* ]]
-  unset MOCK_EXPECT_COMMIT
+@test "--commit rejects a missing argument" {
+  run -1 gh-signoff create --commit
+  [[ "$output" == *"option --commit requires an argument"* ]]
 }
 
-@test "direct partial signoff signs off on specified commit" {
-  export MOCK_EXPECT_COMMIT=def456
-  run -0 gh-signoff --commit def456 linux
-  [[ "$output" == *"Signed off on def456 for linux"* ]]
+@test "--commit rejects an object that is not a commit" {
+  # A blob's sha is 40 hex and the object is right here, but it does not peel
+  # to a commit. Without the local-object check it would pass for unfetched.
+  make_pushed_repo
+  echo contents > file
+  git add file
+  git commit --no-gpg-sign -q -m "Add file"
+  blob=$(git rev-parse HEAD:file)
+
+  run -1 gh-signoff --commit "$blob"
+  [[ "$output" == *"not a commit: $blob"* ]]
+}
+
+@test "--commit refuses a sha with no local object to check" {
+  make_pushed_repo
+  unfetched=0123456789012345678901234567890123456789
+
+  run -1 gh-signoff --commit "$unfetched"
+  [[ "$output" == *"cannot verify ${unfetched} is on a remote"* ]]
+
+  export MOCK_EXPECT_COMMIT="$unfetched"
+  run -0 gh-signoff -f --commit "$unfetched"
+  [[ "$output" == *"Signed off on $unfetched"* ]]
+}
+
+@test "--commit refuses a commit that is on no remote" {
+  make_pushed_repo
+  git commit --no-gpg-sign --allow-empty -m "Unpushed commit" >/dev/null
+  sha=$(git rev-parse HEAD)
+
+  run -1 gh-signoff --commit "$sha"
+  [[ "$output" == *"commit ${sha} is not on any remote"* ]]
+
+  export MOCK_EXPECT_COMMIT="$sha"
+  run -0 gh-signoff -f --commit "$sha"
+  [[ "$output" == *"Signed off on $sha"* ]]
+}
+
+@test "--commit checks the named commit, not the worktree" {
+  make_pushed_repo
+  sha=$(git rev-parse HEAD)
+  touch untracked-file
+  export MOCK_EXPECT_COMMIT="$sha"
+
+  run -0 gh-signoff --commit "$sha"
+  [[ "$output" == *"Signed off on $sha"* ]]
+
   unset MOCK_EXPECT_COMMIT
+  run -1 gh-signoff
+  [[ "$output" == *"repository has uncommitted changes"* ]]
 }
 
 @test "check shows status for protected branch" {
@@ -286,15 +377,16 @@ checkout_fork_pull_request() {
   [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]] || return 1
 }
 
-@test "status checks specified commit" {
+@test "status checks the commit named by --commit" {
   # Mock: Protection requires 'signoff', Commit status has successful 'signoff'
-  export MOCK_EXPECT_COMMIT=abc123
+  make_pushed_repo
+  export MOCK_EXPECT_COMMIT=$(git rev-parse HEAD~1)
   export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff"]}}'
   export MOCK_BRANCH_PROTECTION_EXIT=0
   export MOCK_COMMIT_STATUS_JSON='{"statuses":[{"context":"signoff","state":"success","description":"Test User signed off"}]}'
   export MOCK_COMMIT_STATUS_EXIT=0
 
-  run -0 gh-signoff status --commit abc123
+  run -0 gh-signoff status --commit HEAD~1
   [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]]
 
   unset MOCK_EXPECT_COMMIT MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -136,6 +136,11 @@ checkout_fork_pull_request() {
   unset MOCK_EXPECT_STATUS_SHA
 }
 
+@test "create rejects invalid sha" {
+  run -1 gh-signoff create --sha 'abc/status'
+  [[ "$output" == *"invalid sha: abc/status"* ]]
+}
+
 @test "direct signoff signs off on specified sha" {
   export MOCK_EXPECT_STATUS_SHA=def456
   run -0 gh-signoff --sha def456

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -972,6 +972,15 @@ complete_prefix() {
   [[ "$output" == *"unexpected argument: extra"* ]]
 }
 
+@test "--branch with no argument reports the missing argument" {
+  # $2 was read unguarded, so set -u killed the script before the check ran
+  for command in install uninstall check status; do
+    run -1 gh-signoff "$command" --branch
+    [[ "$output" == *"option --branch requires an argument"* ]]
+    [[ ! "$output" == *"unbound variable"* ]]
+  done
+}
+
 @test "-f after a non-create command is rejected the same as before it" {
   for command in install uninstall check status; do
     run -1 gh-signoff "$command" -f

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -906,9 +906,26 @@ complete_prefix() {
 @test "completion finds the command past a leading --commit" {
   # COMP_WORDS[1] here is --commit, not the command. Reading it directly would
   # offer create's options in the middle of a status invocation.
+  complete_prefix gh-signoff --commit HEAD status --
+  [[ " ${COMPREPLY[*]-} " == *" --branch "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+
+  # Same, past the command's own option, so the option-fallback branch is the
+  # one doing the lookup rather than the previous-word case
   complete_prefix gh-signoff --commit HEAD status --branch main --
   [[ " ${COMPREPLY[*]-} " == *" --branch "* ]]
   [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+}
+
+@test "completion --contexts survives the trailing-argument guard" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff", "signoff/tests"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  # The completion function shells out to this on every tab
+  run -0 gh-signoff completion --contexts
+  [[ "$output" == *"tests"* ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
 
 @test "completion after trailing -f offers contexts without create" {

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -388,8 +388,6 @@ make_pushed_repo() {
 
   run -0 gh-signoff status --commit HEAD~1
   [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]] || return 1
-
-  unset MOCK_EXPECT_COMMIT MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
 }
 
 @test "status shows missing default signoff" {
@@ -877,8 +875,6 @@ complete_prefix() {
 
   complete_words gh-signoff -f
   [[ " ${COMPREPLY[*]-} " == *" --commit "* ]] || return 1
-
-  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
 
 @test "completion after create offers -f and --commit" {
@@ -889,8 +885,6 @@ complete_prefix() {
   [[ " ${COMPREPLY[*]-} " == *" -f "* ]] || return 1
   [[ " ${COMPREPLY[*]-} " == *" --commit "* ]] || return 1
   [[ " ${COMPREPLY[*]-} " == *" linux "* ]] || return 1
-
-  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
 
 @test "completion after --commit suggests nothing" {
@@ -899,8 +893,6 @@ complete_prefix() {
 
   complete_words gh-signoff --commit
   [[ ${#COMPREPLY[@]} -eq 0 ]] || return 1
-
-  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
 
 @test "completion finds the command past a leading --commit" {
@@ -924,8 +916,6 @@ complete_prefix() {
   # The completion function shells out to this on every tab
   run -0 gh-signoff completion --contexts
   [[ "$output" == *"tests"* ]] || return 1
-
-  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
 
 @test "completion after trailing -f offers contexts without create" {

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -145,7 +145,7 @@ make_pushed_repo() {
   export MOCK_EXPECT_COMMIT="$sha"
 
   run -0 gh-signoff create --commit "$sha"
-  [[ "$output" == *"Signed off on $sha"* ]]
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
 }
 
 @test "direct signoff signs off on the commit named by --commit" {
@@ -154,7 +154,7 @@ make_pushed_repo() {
   export MOCK_EXPECT_COMMIT="$sha"
 
   run -0 gh-signoff --commit "$sha"
-  [[ "$output" == *"Signed off on $sha"* ]]
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
 }
 
 @test "direct partial signoff signs off on the commit named by --commit" {
@@ -163,7 +163,7 @@ make_pushed_repo() {
   export MOCK_EXPECT_COMMIT="$sha"
 
   run -0 gh-signoff --commit "$sha" linux
-  [[ "$output" == *"Signed off on $sha for linux"* ]]
+  [[ "$output" == *"Signed off on $sha for linux"* ]] || return 1
 }
 
 @test "--commit takes any revision git resolves" {
@@ -172,7 +172,7 @@ make_pushed_repo() {
   export MOCK_EXPECT_COMMIT="$sha"
 
   run -0 gh-signoff --commit HEAD~1
-  [[ "$output" == *"Signed off on $sha"* ]]
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
 }
 
 @test "--commit expands a short sha to the full 40 hex" {
@@ -181,17 +181,17 @@ make_pushed_repo() {
   export MOCK_EXPECT_COMMIT="$sha"
 
   run -0 gh-signoff --commit "${sha:0:8}"
-  [[ "$output" == *"Signed off on $sha"* ]]
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
 }
 
 @test "--commit rejects a revision git cannot resolve" {
   run -1 gh-signoff create --commit 'abc/status'
-  [[ "$output" == *"invalid commit: abc/status"* ]]
+  [[ "$output" == *"invalid commit: abc/status"* ]] || return 1
 }
 
 @test "--commit rejects a missing argument" {
   run -1 gh-signoff create --commit
-  [[ "$output" == *"option --commit requires an argument"* ]]
+  [[ "$output" == *"option --commit requires an argument"* ]] || return 1
 }
 
 @test "--commit rejects an object that is not a commit" {
@@ -204,7 +204,7 @@ make_pushed_repo() {
   blob=$(git rev-parse HEAD:file)
 
   run -1 gh-signoff --commit "$blob"
-  [[ "$output" == *"not a commit: $blob"* ]]
+  [[ "$output" == *"not a commit: $blob"* ]] || return 1
 }
 
 @test "--commit refuses a sha with no local object to check" {
@@ -212,11 +212,11 @@ make_pushed_repo() {
   unfetched=0123456789012345678901234567890123456789
 
   run -1 gh-signoff --commit "$unfetched"
-  [[ "$output" == *"cannot verify ${unfetched} is on a remote"* ]]
+  [[ "$output" == *"cannot verify ${unfetched} is on a remote"* ]] || return 1
 
   export MOCK_EXPECT_COMMIT="$unfetched"
   run -0 gh-signoff -f --commit "$unfetched"
-  [[ "$output" == *"Signed off on $unfetched"* ]]
+  [[ "$output" == *"Signed off on $unfetched"* ]] || return 1
 }
 
 @test "--commit refuses a commit that is on no remote" {
@@ -225,11 +225,11 @@ make_pushed_repo() {
   sha=$(git rev-parse HEAD)
 
   run -1 gh-signoff --commit "$sha"
-  [[ "$output" == *"commit ${sha} is not on any remote"* ]]
+  [[ "$output" == *"commit ${sha} is not on any remote"* ]] || return 1
 
   export MOCK_EXPECT_COMMIT="$sha"
   run -0 gh-signoff -f --commit "$sha"
-  [[ "$output" == *"Signed off on $sha"* ]]
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
 }
 
 @test "--commit checks the named commit, not the worktree" {
@@ -239,11 +239,11 @@ make_pushed_repo() {
   export MOCK_EXPECT_COMMIT="$sha"
 
   run -0 gh-signoff --commit "$sha"
-  [[ "$output" == *"Signed off on $sha"* ]]
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
 
   unset MOCK_EXPECT_COMMIT
   run -1 gh-signoff
-  [[ "$output" == *"repository has uncommitted changes"* ]]
+  [[ "$output" == *"repository has uncommitted changes"* ]] || return 1
 }
 
 @test "check shows status for protected branch" {
@@ -387,7 +387,7 @@ make_pushed_repo() {
   export MOCK_COMMIT_STATUS_EXIT=0
 
   run -0 gh-signoff status --commit HEAD~1
-  [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]]
+  [[ "$output" == *"${STATUS_SUCCESS} signoff"* ]] || return 1
 
   unset MOCK_EXPECT_COMMIT MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
 }
@@ -876,7 +876,7 @@ complete_prefix() {
   export MOCK_BRANCH_PROTECTION_EXIT=0
 
   complete_words gh-signoff -f
-  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]] || return 1
 
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
@@ -886,9 +886,9 @@ complete_prefix() {
   export MOCK_BRANCH_PROTECTION_EXIT=0
 
   complete_words gh-signoff create
-  [[ " ${COMPREPLY[*]-} " == *" -f "* ]]
-  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
-  [[ " ${COMPREPLY[*]-} " == *" linux "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" -f "* ]] || return 1
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]] || return 1
+  [[ " ${COMPREPLY[*]-} " == *" linux "* ]] || return 1
 
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
@@ -898,7 +898,7 @@ complete_prefix() {
   export MOCK_BRANCH_PROTECTION_EXIT=0
 
   complete_words gh-signoff --commit
-  [[ ${#COMPREPLY[@]} -eq 0 ]]
+  [[ ${#COMPREPLY[@]} -eq 0 ]] || return 1
 
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
@@ -907,14 +907,14 @@ complete_prefix() {
   # COMP_WORDS[1] here is --commit, not the command. Reading it directly would
   # offer create's options in the middle of a status invocation.
   complete_prefix gh-signoff --commit HEAD status --
-  [[ " ${COMPREPLY[*]-} " == *" --branch "* ]]
-  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" --branch "* ]] || return 1
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]] || return 1
 
   # Same, past the command's own option, so the option-fallback branch is the
   # one doing the lookup rather than the previous-word case
   complete_prefix gh-signoff --commit HEAD status --branch main --
-  [[ " ${COMPREPLY[*]-} " == *" --branch "* ]]
-  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" --branch "* ]] || return 1
+  [[ " ${COMPREPLY[*]-} " == *" --commit "* ]] || return 1
 }
 
 @test "completion --contexts survives the trailing-argument guard" {
@@ -923,7 +923,7 @@ complete_prefix() {
 
   # The completion function shells out to this on every tab
   run -0 gh-signoff completion --contexts
-  [[ "$output" == *"tests"* ]]
+  [[ "$output" == *"tests"* ]] || return 1
 
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
@@ -963,45 +963,45 @@ complete_prefix() {
               "uninstall --commit nope" "--commit nope uninstall" \
               "check --commit nope" "--commit nope check"; do
     run -1 gh-signoff $args
-    [[ "$output" == *"--commit is only valid for create and status"* ]]
-    [[ ! "$output" == *"invalid commit"* ]]
+    [[ "$output" == *"--commit is only valid for create and status"* ]] || return 1
+    [[ ! "$output" == *"invalid commit"* ]] || return 1
   done
 }
 
 @test "leading --commit requires an argument" {
   run -1 gh-signoff --commit
-  [[ "$output" == *"option --commit requires an argument"* ]]
+  [[ "$output" == *"option --commit requires an argument"* ]] || return 1
 
   run -1 gh-signoff --commit -f
-  [[ "$output" == *"option --commit requires an argument"* ]]
+  [[ "$output" == *"option --commit requires an argument"* ]] || return 1
 }
 
 @test "leading --commit passes its argument through as one word" {
   run -1 gh-signoff --commit "foo bar"
-  [[ "$output" == *"invalid commit: foo bar"* ]]
+  [[ "$output" == *"invalid commit: foo bar"* ]] || return 1
 }
 
 @test "trailing arguments are reported rather than ignored" {
   run -1 gh-signoff version --commit nope
-  [[ "$output" == *"unexpected argument: --commit"* ]]
+  [[ "$output" == *"unexpected argument: --commit"* ]] || return 1
 
   run -1 gh-signoff completion --contexts extra
-  [[ "$output" == *"unexpected argument: extra"* ]]
+  [[ "$output" == *"unexpected argument: extra"* ]] || return 1
 }
 
 @test "--branch with no argument reports the missing argument" {
   # $2 was read unguarded, so set -u killed the script before the check ran
   for command in install uninstall check status; do
     run -1 gh-signoff "$command" --branch
-    [[ "$output" == *"option --branch requires an argument"* ]]
-    [[ ! "$output" == *"unbound variable"* ]]
+    [[ "$output" == *"option --branch requires an argument"* ]] || return 1
+    [[ ! "$output" == *"unbound variable"* ]] || return 1
   done
 }
 
 @test "-f after a non-create command is rejected the same as before it" {
   for command in install uninstall check status; do
     run -1 gh-signoff "$command" -f
-    [[ "$output" == *"-f is only valid for create"* ]]
+    [[ "$output" == *"-f is only valid for create"* ]] || return 1
   done
 }
 

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -219,6 +219,38 @@ make_pushed_repo() {
   [[ "$output" == *"Signed off on $unfetched"* ]] || return 1
 }
 
+@test "--commit accepts a commit published to a URL-tracked remote" {
+  # A branch checked out from a fork pull request has no remote-tracking refs,
+  # so `git branch -r --contains` finds nothing. Plain signoff proves the
+  # commit is on the fork over ls-remote; --commit must reach the same answer
+  # rather than demanding -f for naming the very commit it just accepted.
+  make_nested_repo
+  checkout_fork_pull_request
+  sha=$(git rev-parse HEAD)
+  [[ -z "$(git branch -r --contains "$sha")" ]] || return 1
+
+  export MOCK_EXPECT_COMMIT="$sha"
+  run -0 gh-signoff --commit "$sha"
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
+
+  run -0 gh-signoff status --commit "$sha"
+  [[ "$output" == *"signoff"* ]] || return 1
+}
+
+@test "--commit still refuses an unpushed commit on a URL-tracked remote" {
+  make_nested_repo
+  checkout_fork_pull_request
+  git commit --no-gpg-sign --allow-empty -m "Unpushed commit" >/dev/null
+  sha=$(git rev-parse HEAD)
+
+  run -1 gh-signoff --commit "$sha"
+  [[ "$output" == *"is not on any remote"* ]] || return 1
+
+  export MOCK_EXPECT_COMMIT="$sha"
+  run -0 gh-signoff -f --commit "$sha"
+  [[ "$output" == *"Signed off on $sha"* ]] || return 1
+}
+
 @test "--commit refuses a commit that is on no remote" {
   make_pushed_repo
   git commit --no-gpg-sign --allow-empty -m "Unpushed commit" >/dev/null

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -889,6 +889,47 @@ complete_words() {
   [[ "$output" == *"-f is only valid for create"* ]] || return 1
 }
 
+# Leading --commit dispatcher grammar tests
+@test "leading --commit is rejected for commands that do not take it" {
+  # Both orders must give the same answer. The leading form is also the
+  # regression test against resolving the revision before the command is known.
+  for args in "install --commit nope" "--commit nope install" \
+              "uninstall --commit nope" "--commit nope uninstall" \
+              "check --commit nope" "--commit nope check"; do
+    run -1 gh-signoff $args
+    [[ "$output" == *"--commit is only valid for create and status"* ]]
+    [[ ! "$output" == *"invalid commit"* ]]
+  done
+}
+
+@test "leading --commit requires an argument" {
+  run -1 gh-signoff --commit
+  [[ "$output" == *"option --commit requires an argument"* ]]
+
+  run -1 gh-signoff --commit -f
+  [[ "$output" == *"option --commit requires an argument"* ]]
+}
+
+@test "leading --commit passes its argument through as one word" {
+  run -1 gh-signoff --commit "foo bar"
+  [[ "$output" == *"invalid commit: foo bar"* ]]
+}
+
+@test "trailing arguments are reported rather than ignored" {
+  run -1 gh-signoff version --commit nope
+  [[ "$output" == *"unexpected argument: --commit"* ]]
+
+  run -1 gh-signoff completion --contexts extra
+  [[ "$output" == *"unexpected argument: extra"* ]]
+}
+
+@test "-f after a non-create command is rejected the same as before it" {
+  for command in install uninstall check status; do
+    run -1 gh-signoff "$command" -f
+    [[ "$output" == *"-f is only valid for create"* ]]
+  done
+}
+
 @test "@{push} stays authoritative over upstream when both resolve" {
   # Triangular setup: feature tracks origin/main (which contains HEAD), but
   # push.default=current resolves @{push} to origin/feature, which lacks HEAD.


### PR DESCRIPTION
## Summary

This adds a `--commit` option to `create` and `status`, so signoff can target a specific commit instead of always resolving `HEAD`.

This is useful for workflows like [GitButler](https://gitbutler.com/), where stacked or virtual branches can expose the exact commit that needs signoff, while the local working tree may not map cleanly to that commit as `HEAD`.

With this change, users can run:

```bash
gh signoff --commit abc1234
gh signoff --commit HEAD~1 tests
gh signoff create --commit abc1234
gh signoff status --commit abc1234
```

When `--commit` is not provided, the existing behavior is unchanged and the command continues to use the current commit.

## Changes on top of the original two commits

Rebased onto `main` (#16 rewrote `is_clean`, the `cmd_create` force check, the dispatcher and the completion function — every region this touches), then:

- **`--sha` is now `--commit`.** `gh` has no `--sha` anywhere; it consistently spells this `-c, --commit SHA` (`gh run list`, `gh browse`). `--sha` never shipped, so there is no alias to keep.
- **The argument is resolved through `git rev-parse`** rather than regex-validated. Any revision works — `HEAD~1`, a tag, a branch, a short sha — and always expands to a full 40-hex commit, which closes the path-interpolation concern by construction. An object that exists locally but doesn't peel to a commit (a tree, a blob) is reported as such; only a 40-hex string git has never seen is treated as a possibly-unfetched commit.
- **The pushed check still applies, to the named commit.** Worktree cleanliness doesn't — it says nothing about a commit you name — but "is this commit on a remote?" does, so `--commit` is no longer an undocumented `-f`. The check asks remote-tracking refs directly rather than going through `@{push}`, which is current-branch-relative and would reject exactly the stacked and virtual-branch commits this option exists for. `-f` overrides, as ever.
- **`--commit` may precede the command** (`gh signoff --commit X tests`, `gh signoff -f --commit X`), and is rejected in both positions for `install`/`uninstall`/`check`. `-f` gets the same treatment, closing an identical pre-existing asymmetry where `gh signoff install -f` answered "unknown option" but `gh signoff -f install` answered "-f is only valid for create".
- **Completion** finds the command by scanning past the global options instead of reading `COMP_WORDS[1]`, which is now the option when one leads.
- **Two pre-existing fixes while in here:** `--branch` with no argument died on `set -u` with a raw `$2: unbound variable`; `version`, `completion` and `--help` silently ignored whatever trailed them.
- `VERSION` 0.2.1 → 0.3.0.

Copilot's four review comments are all addressed: two (completion offering `-f` for `create`, `--sha` offered for commands that don't take it) by the rebase onto #16 plus the completion rework, and the two about unvalidated interpolation into the API path structurally, by resolving through git.

## Testing

65 bats tests, green on Bash 3, 4 and 5.
