### PR TITLE
Fix Windows CRLF handling in signoff status

### DIFF
--- a/gh-signoff
+++ b/gh-signoff
@@ -476,6 +476,7 @@ cmd_status() {
   if [[ -n "$protection" ]]; then
     # Add required signoff contexts from branch protection
     while read -r ctx; do
+      ctx=${ctx%$'\r'}
       [[ -z "$ctx" || "$ctx" == "signoff" ]] && continue  # Skip empty or default signoff (already included)
       required+=("$ctx")
     done < <(echo "$protection" | jq -r '.required_status_checks?.contexts? | map(select(startswith("signoff"))) | .[]?' 2>/dev/null || echo "")
@@ -488,6 +489,8 @@ cmd_status() {
 
   # Extract all contexts with success state
   while IFS=$'\t' read -r context state; do
+    context=${context%$'\r'}
+    state=${state%$'\r'}
     [[ -z "$context" ]] && continue
     # Add to our string-based map
     context_map="${context_map}${context}=${state};"
@@ -495,6 +498,7 @@ cmd_status() {
 
   # Add any actual contexts that aren't in required list
   while read -r context; do
+    context=${context%$'\r'}
     [[ -z "$context" ]] && continue
 
     # Check if this context is already in required list

--- a/gh-signoff
+++ b/gh-signoff
@@ -3,7 +3,7 @@ set -euo pipefail
 # set -x # Keep this commented out unless actively debugging
 
 DEBUG=${SIGNOFF_DEBUG:-}
-readonly VERSION="0.2.1"
+readonly VERSION="0.2.2"
 
 # Status symbols for consistent display - export them for both script and tests
 export STATUS_SUCCESS="✓"
@@ -40,40 +40,44 @@ fail() {
 }
 
 # Get default branch with caching
+#
+# Two conventions apply to every gh call below. Filtering uses gh's built-in
+# --jq rather than an external jq: gh is the only dependency this script checks
+# for at startup, and being Go it never translates line endings the way jq does
+# on Windows. Captures still get their CRs stripped anyway, since we can't test
+# Windows from here and a stray \r matches nothing. And gh prints API error
+# bodies to stdout, so every failure path has to reset its capture rather than
+# leave {"message":"Not Found"} looking like a response.
 default_branch() {
   if [[ -z "$DEFAULT_BRANCH" ]]; then
-    DEFAULT_BRANCH=$(gh api repos/:owner/:repo --jq .default_branch 2>/dev/null) || return 1
+    DEFAULT_BRANCH=$(gh api repos/:owner/:repo --jq .default_branch 2>/dev/null) || {
+      DEFAULT_BRANCH=""
+      return 1
+    }
+    DEFAULT_BRANCH=${DEFAULT_BRANCH//$'\r'/}
   fi
   echo "$DEFAULT_BRANCH"
 }
 
-# Get signoff contexts from branch protection
+# Get signoff contexts from branch protection, stripping the 'signoff/' prefix.
+# select() drops the bare 'signoff' context, which has no display name.
 get_signoff_contexts() {
   local branch="${1:-}"
-  local contexts=()
 
   # If branch not specified, use default branch
   if [[ -z "$branch" ]]; then
     branch=$(default_branch) || return 0
   fi
 
-  # Get branch protection
-  local protection
-  protection=$(gh api "repos/:owner/:repo/branches/${branch}/protection" 2>/dev/null) || return 0
+  local contexts
+  contexts=$(gh api "repos/:owner/:repo/branches/${branch}/protection" \
+    --jq '.required_status_checks.contexts[]? | select(startswith("signoff/")) | ltrimstr("signoff/")' \
+    2>/dev/null) || return 0
+  contexts=${contexts//$'\r'/}
 
-  # Extract signoff contexts (strip 'signoff/' prefix for display)
-  while read -r ctx; do
-    [[ -z "$ctx" ]] && continue
-    if [[ "$ctx" == "signoff/"* ]]; then
-      contexts+=("${ctx#signoff/}")
-    elif [[ "$ctx" == "signoff" ]]; then
-      # Skip the default signoff context
-      continue
-    fi
-  done < <(echo "$protection" | jq -r '.required_status_checks?.contexts? | map(select(startswith("signoff"))) | .[]?' 2>/dev/null || echo "")
-
-  # Return contexts
-  printf "%s\n" "${contexts[@]}"
+  if [[ -n "$contexts" ]]; then
+    echo "$contexts"
+  fi
 }
 
 # @{upstream} is a sound stand-in for an unresolvable @{push} only in the
@@ -389,9 +393,10 @@ cmd_check() {
     contexts=("")
   fi
 
-  # Fetch branch protection once
-  local protection
-  protection=$(gh api "repos/:owner/:repo/branches/${branch}/protection" 2>/dev/null) || {
+  # Fetch the required contexts once, one per line
+  local protection_contexts
+  protection_contexts=$(gh api "repos/:owner/:repo/branches/${branch}/protection" \
+    --jq '.required_status_checks.contexts[]?' 2>/dev/null) || {
     for context in "${contexts[@]}"; do
       if [[ -z "$context" ]]; then
         echo "${STATUS_FAILURE} GitHub ${branch} branch does not require signoff"
@@ -401,6 +406,7 @@ cmd_check() {
     done
     return 1
   }
+  protection_contexts=${protection_contexts//$'\r'/}
 
   # Check each context
   for context in "${contexts[@]}"; do
@@ -411,7 +417,8 @@ cmd_check() {
 
     debug "checking protection for branch: ${branch} with context: ${context_name}"
 
-    if echo "$protection" | jq -e ".required_status_checks.contexts | contains([\"${context_name}\"])" >/dev/null 2>&1; then
+    # Whole-line match, so 'signoff' isn't satisfied by 'signoff/tests'
+    if [[ $'\n'"$protection_contexts"$'\n' == *$'\n'"${context_name}"$'\n'* ]]; then
       if [[ -z "$context" ]]; then
         echo "${STATUS_SUCCESS} GitHub ${branch} branch requires signoff"
       else
@@ -460,61 +467,50 @@ cmd_status() {
   # Get current SHA
   sha=$(git rev-parse HEAD) || fail "failed to get current commit"
 
-  # Get commit statuses
+  # Get the signoff statuses on this commit as context/state pairs. A filter
+  # error surfaces here rather than silently rendering every context as failed.
   local statuses
-  statuses=$(gh api "repos/:owner/:repo/commits/${sha}/status" 2>/dev/null) || {
+  statuses=$(gh api "repos/:owner/:repo/commits/${sha}/status" \
+    --jq '.statuses[]? | select(.context? | startswith("signoff")) | [.context, .state] | @tsv' \
+    2>/dev/null) || {
     echo "${STATUS_FAILURE} Could not get status for commit ${sha}"
     return 1
   }
+  statuses=${statuses//$'\r'/}
 
   # Create required contexts list - always start with "signoff"
   local required=("signoff")
 
   # Add any additional contexts from branch protection
-  local protection
-  protection=$(gh api "repos/:owner/:repo/branches/${branch}/protection" 2>/dev/null) || debug "No branch protection found"
-  if [[ -n "$protection" ]]; then
-    # Add required signoff contexts from branch protection
-    while read -r ctx; do
-      ctx=${ctx%$'\r'}
-      [[ -z "$ctx" || "$ctx" == "signoff" ]] && continue  # Skip empty or default signoff (already included)
-      required+=("$ctx")
-    done < <(echo "$protection" | jq -r '.required_status_checks?.contexts? | map(select(startswith("signoff"))) | .[]?' 2>/dev/null || echo "")
-  fi
+  local protection_contexts
+  protection_contexts=$(gh api "repos/:owner/:repo/branches/${branch}/protection" \
+    --jq '.required_status_checks.contexts[]? | select(startswith("signoff"))' \
+    2>/dev/null) || {
+    debug "No branch protection found"
+    protection_contexts=""
+  }
+  protection_contexts=${protection_contexts//$'\r'/}
 
-  # Extract context/state pairs into a string-based lookup map
-  # Format: "context1=state1;context2=state2;..."
-  # This is a lightweight alternative to associative arrays for Bash 3
-  local context_map=""
+  local ctx
+  while read -r ctx; do
+    [[ -z "$ctx" || "$ctx" == "signoff" ]] && continue  # Skip empty or default signoff (already included)
+    required+=("$ctx")
+  done <<< "$protection_contexts"
 
-  # Extract all contexts with success state
+  # Map contexts to states as "context1=state1;context2=state2;..."
+  # A lightweight stand-in for associative arrays, which Bash 3 lacks
+  local context_map="" context state found req
   while IFS=$'\t' read -r context state; do
-    context=${context%$'\r'}
-    state=${state%$'\r'}
     [[ -z "$context" ]] && continue
-    # Add to our string-based map
     context_map="${context_map}${context}=${state};"
-  done < <(echo "$statuses" | jq -r '.statuses[]? | select(.context? | startswith("signoff")) | [.context, .state] | @tsv' 2>/dev/null || echo "")
 
-  # Add any actual contexts that aren't in required list
-  while read -r context; do
-    context=${context%$'\r'}
-    [[ -z "$context" ]] && continue
-
-    # Check if this context is already in required list
-    local found=false
+    # Show contexts that were signed off even if protection doesn't require them
+    found=false
     for req in "${required[@]}"; do
-      if [[ "$req" == "$context" ]]; then
-        found=true
-        break
-      fi
+      [[ "$req" == "$context" ]] && { found=true; break; }
     done
-
-    # If not in required list, add it
-    if [[ "$found" == "false" ]]; then
-      required+=("$context")
-    fi
-  done < <(echo "$statuses" | jq -r '.statuses[]? | select(.context? | startswith("signoff")) | .context' 2>/dev/null || echo "")
+    $found || required+=("$context")
+  done <<< "$statuses"
 
   # Generate status output for all contexts (required + actual)
   local all_results=()

--- a/test/mocks/gh
+++ b/test/mocks/gh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# --- Windows Line Endings ---
+# Re-run ourselves and CRLF-terminate every line of stdout, standing in for a
+# toolchain that hands the shell \r-terminated output. Covers the whole mock
+# surface in one place rather than per response.
+if [[ -n "${MOCK_CRLF:-}" ]]; then
+  rc=0
+  MOCK_CRLF="" "$0" "$@" | sed $'s/$/\r/' || rc=$?
+  exit $rc
+fi
+
 # --- Default Mock Responses & Exit Codes ---
 # These can be overridden by environment variables in specific tests
 : ${MOCK_DEFAULT_BRANCH_JSON:='{"default_branch":"main"}'}
@@ -71,14 +81,32 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# --- Response Helpers ---
+
+# Apply --jq to the response body the way gh's built-in jq does
+emit() {
+  if [[ -n "$jq_filter" ]]; then
+    echo "$1" | jq -r "$jq_filter"
+  else
+    echo "$1"
+  fi
+}
+
+# gh prints the API error body to stdout and exits nonzero, so callers have to
+# reset their capture rather than treat the body as a response
+emit_error() {
+  echo "{\"message\":\"$1\",\"documentation_url\":\"https://docs.github.com/rest\",\"status\":\"404\"}"
+}
+
 # --- Determine Response Based on API Call ---
 
 # Default Branch Call
 if [[ "$api_path" == "repos/:owner/:repo" && "$jq_filter" == ".default_branch" ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched GET Default Branch" >&2
   if [[ "$MOCK_DEFAULT_BRANCH_EXIT" -eq 0 ]]; then
-    # Extract just the default_branch value using jq, not the entire JSON
-    echo "$MOCK_DEFAULT_BRANCH_JSON" | jq -r '.default_branch'
+    emit "$MOCK_DEFAULT_BRANCH_JSON"
+  else
+    emit_error "Not Found"
   fi
   exit "$MOCK_DEFAULT_BRANCH_EXIT"
 
@@ -86,7 +114,9 @@ if [[ "$api_path" == "repos/:owner/:repo" && "$jq_filter" == ".default_branch" ]
 elif [[ "$api_method" == "GET" && "$api_path" == *"commits/"*"/status"* ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched GET Commit Status" >&2
   if [[ "$MOCK_COMMIT_STATUS_EXIT" -eq 0 ]]; then
-    echo "$MOCK_COMMIT_STATUS_JSON"
+    emit "$MOCK_COMMIT_STATUS_JSON"
+  else
+    emit_error "Not Found"
   fi
   exit "$MOCK_COMMIT_STATUS_EXIT"
 
@@ -94,7 +124,9 @@ elif [[ "$api_method" == "GET" && "$api_path" == *"commits/"*"/status"* ]]; then
 elif [[ "$api_method" == "GET" && "$api_path" == *"branches/"*"/protection"* ]]; then
   [[ -n "${GH_MOCK_DEBUG:-}" ]] && echo "Mock: Matched GET Branch Protection" >&2
   if [[ "$MOCK_BRANCH_PROTECTION_EXIT" -eq 0 ]]; then
-    echo "$MOCK_BRANCH_PROTECTION_JSON"
+    emit "$MOCK_BRANCH_PROTECTION_JSON"
+  else
+    emit_error "Branch not protected"
   fi
   exit "$MOCK_BRANCH_PROTECTION_EXIT"
 

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -239,6 +239,28 @@ add_bare_remote() {
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
 }
 
+@test "status handles CRLF output from jq" {
+  # Reproduce the CRLF emitted by jq on Windows while keeping the test portable.
+  local jq_path
+  jq_path="$(command -v jq)"
+  cat > "$TEST_DIR/jq" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+"$jq_path" "\$@" | sed 's/\r$//; s/\$/\r/'
+EOF
+  chmod +x "$TEST_DIR/jq"
+
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff", "signoff/tests"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+  export MOCK_COMMIT_STATUS_JSON='{"statuses":[{"context":"signoff","state":"success","description":"Test User signed off"},{"context":"signoff/tests","state":"success","description":"Test User signed off"}]}'
+  export MOCK_COMMIT_STATUS_EXIT=0
+
+  run -0 gh-signoff status
+  [[ "$output" == $'✓ signoff\n✓ tests' ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
+}
+
 @test "status shows signoffs even without branch protection" {
   # Mock: No protection (exit 1), Commit status has 'tests' and 'lint' successful
   export MOCK_BRANCH_PROTECTION_EXIT=1

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -239,26 +239,59 @@ add_bare_remote() {
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
 }
 
-@test "status handles CRLF output from jq" {
-  # Reproduce the CRLF emitted by jq on Windows while keeping the test portable.
-  local jq_path
-  jq_path="$(command -v jq)"
-  cat > "$TEST_DIR/jq" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-"$jq_path" "\$@" | sed 's/\r$//; s/\$/\r/'
-EOF
-  chmod +x "$TEST_DIR/jq"
-
+# MOCK_CRLF makes the gh mock terminate every line with \r\n, standing in for
+# the CRLF a Windows toolchain can hand back. A stray \r turns "success" into a
+# state that matches nothing and "signoff" into a second, distinct context, so
+# these assert exact output rather than substrings.
+#
+# Each ends on its assertion, with no trailing unset: bash 3.2's set -e does not
+# fire for a failing [[ ]] inside a function, so any command after the assertion
+# becomes the test's exit status and the assertion stops being enforced. Bats
+# runs each test in its own process, so the exports do not leak regardless.
+@test "status tolerates CRLF from gh on Windows" {
+  export MOCK_CRLF=1
   export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff", "signoff/tests"]}}'
   export MOCK_BRANCH_PROTECTION_EXIT=0
   export MOCK_COMMIT_STATUS_JSON='{"statuses":[{"context":"signoff","state":"success","description":"Test User signed off"},{"context":"signoff/tests","state":"success","description":"Test User signed off"}]}'
   export MOCK_COMMIT_STATUS_EXIT=0
 
   run -0 gh-signoff status
-  [[ "$output" == $'✓ signoff\n✓ tests' ]]
+  [[ "$output" == "${STATUS_SUCCESS} signoff"$'\n'"${STATUS_SUCCESS} tests" ]]
+}
 
-  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT MOCK_COMMIT_STATUS_JSON MOCK_COMMIT_STATUS_EXIT
+@test "check tolerates CRLF from gh on Windows" {
+  export MOCK_CRLF=1
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff", "signoff/tests"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  run -0 gh-signoff check
+  [[ "$output" == "${STATUS_SUCCESS} GitHub main branch requires signoff" ]]
+}
+
+@test "check on a named context tolerates CRLF from gh on Windows" {
+  export MOCK_CRLF=1
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff", "signoff/tests"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  run -0 gh-signoff check tests
+  [[ "$output" == "${STATUS_SUCCESS} GitHub main branch requires signoff on tests" ]]
+}
+
+@test "completion contexts tolerate CRLF from gh on Windows" {
+  export MOCK_CRLF=1
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff", "signoff/tests", "signoff/lint"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  run -0 gh-signoff completion --contexts
+  [[ "$output" == "tests"$'\n'"lint" ]]
+}
+
+@test "completion contexts are empty when only plain signoff is required" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  run -0 gh-signoff completion --contexts
+  [[ -z "$output" ]]
 }
 
 @test "status shows signoffs even without branch protection" {


### PR DESCRIPTION
Fixes #13

## Summary

- Strip trailing carriage returns from values parsed from `jq` in `gh signoff status`.
- Add a regression test that simulates CRLF output from `jq`.
- Normalize the test wrapper so it produces exactly one CRLF on both Unix and Windows.

## Root cause

On Windows, `jq -r` emits CRLF. Bash `read` removes the line-feed but leaves the carriage return, causing successful `signoff` statuses to be compared as `success\r` and contexts to be treated as distinct values.

## Impact

Windows users can see a false `✗ signoff` result, sometimes duplicated, even though the GitHub commit status is successful.

## Validation

- [x] `bash -n gh-signoff`: pass
- [x] `git diff --check`: pass
- [x] Windows smoke test against a real successful commit: `✓ signoff`
- [x] `GH_REPO=YukiWorks432/gh-signoff gh signoff` on head `bfc0da2708c2e543ca96df84cc13723d9ef6e97e`: pass
- [x] `GH_REPO=YukiWorks432/gh-signoff gh signoff status --branch main`: `✓ signoff`
- [x] GitHub API for the same head: `signoff\tsuccess`
- [x] Docker `gh-signoff-test:bash3`: 28/28 tests passed
- [x] Docker `gh-signoff-test:bash4`: 28/28 tests passed
- [x] Docker `gh-signoff-test:bash5`: 28/28 tests passed

The Docker images were run with an explicit Windows absolute bind mount. Invoking `bin/ci` through Git Bash could not mount the repository because of Windows path conversion, so the same three official test images were run directly with the corrected mount path.

The source change is limited to the status parser and its regression test.


---

## Maintainer addendum (jeremy)

Everything above is @YukiWorks432's original description and is preserved as written. It now describes only the **first** of two commits, so this note brings the PR up to date. I rebased onto `main` and force-pushed, so `bfc0da2` is now `059fd31` — same author, date, message, and byte-identical added lines.

The follow-up commit fixes this at the root: `gh` ships `jq` built in, and being Go it never translates line endings, so filtering with `gh api --jq` instead of piping to an external `jq` removes the bug class outright. **That supersedes the four `${x%$'\r'}` strips and the `jq`-shim test** — the strips patched each read site but missed the identical bug in `get_signoff_contexts()` (which feeds shell completion), and the shim test shadowed a `jq` binary the code no longer invokes, so it would have gone green regardless.

Corrections to the summary above, now that scope has grown:

- **Files:** 3, not 2 — `gh-signoff`, `test/signoff.bats`, and `test/mocks/gh` (generic `--jq`, error bodies on failure, and a `MOCK_CRLF` hook).
- **Scope:** not limited to the status parser. Five functions changed: `default_branch`, `get_signoff_contexts`, `cmd_check`, `cmd_status`, plus the version constant (0.2.1 → 0.2.2).
- **Tests:** 47 passing on bash 3.2/4/5, not 28/28.
- **No external `jq` invocation remains** in `gh-signoff`; only `gh api --jq` flags.

Four further bugs fixed along the way, all pre-existing:

- **`jq` was an undeclared dependency.** Startup checks `git` and `gh` but never `jq`, and the `2>/dev/null || echo ""` fallbacks turned its absence into *wrong answers* rather than errors. Verified live: with `jq` off `PATH`, the old script prints `✗ signoff` for a commit that is signed off.
- **`cmd_status` walked the status payload twice** with two different filters; the first pass already sees every `signoff*` context. Now one pass.
- **`get_signoff_contexts` crashed on bash 3.2** whenever protection required plain `signoff` with no `signoff/*` contexts — the default `gh signoff install` setup — because `printf "%s\n" "${contexts[@]}"` expands an empty array under `set -u`.
- **`cmd_check` used jq's `contains()`**, which is substring matching, so `signoff` looked satisfied by `signoff/tests` alone. Now matches whole lines.

`gh` shouldn't emit CRLF at all, but none of us can test Windows from here and that's the point of #13, so each captured string is still normalized once — five sites, including `default_branch`, whose `\r` otherwise lands in every API URL path built from it. One of @YukiWorks432's CRLF tests caught that site.

A filter error now exits nonzero, so a malformed payload surfaces as "Could not get status" rather than silently rendering everything `✗`.

### Verification

- `bash -n gh-signoff`; no external `jq` in the product.
- 47 tests pass on bash 3.2, 4 and 5 (baseline was 43).
- **Negative check:** all four CRLF tests fail on all three bash versions with the normalization removed.
- bash 3.2 `completion --contexts` crash fixed (was `line 76: contexts[@]: unbound variable`, now exit 0, no output).
- Live smoke with real `gh` against a commit carrying a real `signoff success`, with a poisoned `jq` first on `PATH` to prove nothing shells out to it. Prints exactly `✓ signoff`; the pre-fix script prints `✗ signoff`.

### Outstanding before merge

- [ ] **Windows confirmation from @YukiWorks432** — the one gate we can't clear ourselves.
- Note there are no CI checks on this PR, so green status here does not exercise the suite.

Two pre-existing issues found while smoking this are deliberately **not** in scope and are getting their own PRs: the ERR trap firing on `gh signoff check` for unprotected branches, and bats assertion enforcement on bash 3.2 (a failing `[[ ]]` doesn't trip `set -e` there, so a trailing `unset` silently disarms the assertion).
