### PR TITLE
Fall back to @{upstream} when @{push} does not resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ gh extension install basecamp/gh-signoff
 gh signoff
 ```
 
+Without `-f`, signoff requires HEAD to be contained in `@{push}`, or in `@{upstream}` when no push destination resolves. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
+
 ### To require signoff for PR merges
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gh extension install basecamp/gh-signoff
 gh signoff
 ```
 
-Without `-f`, signoff requires HEAD to be contained in `@{push}`, or in `@{upstream}` when no push destination resolves. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
+Without `-f`, signoff requires HEAD to be contained in `@{push}` — or in `@{upstream}` when no push destination resolves and no configuration (`branch.<name>.pushRemote`, `remote.pushDefault`, or push refspecs) reroutes pushes away from the upstream remote. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
 
 ### To require signoff for PR merges
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gh extension install basecamp/gh-signoff
 gh signoff
 ```
 
-Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
+Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote whose single push URL matches its fetch URL, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
 
 ### To require signoff for PR merges
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gh extension install basecamp/gh-signoff
 gh signoff
 ```
 
-Without `-f`, signoff requires HEAD to be contained in `@{push}` — or in `@{upstream}` when no push destination resolves and no configuration (`branch.<name>.pushRemote`, `remote.pushDefault`, or push refspecs) reroutes pushes away from the upstream remote. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
+Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
 
 ### To require signoff for PR merges
 

--- a/gh-signoff
+++ b/gh-signoff
@@ -607,27 +607,36 @@ COMPLETION
 EOF
 }
 
+# A leading -f applies to create (explicit, implicit, or contextual)
+# and is rejected for every other command
+force=""
+if [[ "${1:-}" == "-f" ]]; then
+  force="-f"
+  shift
+fi
+
+reject_force() {
+  if [[ -n "$force" ]]; then
+    fail "-f is only valid for create"
+  fi
+}
+
 case "${1:-}" in
-  "")               cmd_create "$@" ;;
-  "create")         shift; cmd_create "$@" ;;
-  "install")        shift; cmd_install "$@" ;;
-  "uninstall")      shift; cmd_uninstall "$@" ;;
-  "check")          shift; cmd_check "$@" ;;
-  "status")         shift; cmd_status "$@" ;;
-  "version")        cmd_version ;;
-  "completion")     shift; cmd_completion "$@" ;;
-  "-h" | "--help")  cmd_help ;;
+  "")               cmd_create ${force:+-f} ;;
+  "create")         shift; cmd_create ${force:+-f} "$@" ;;
+  "install")        reject_force; shift; cmd_install "$@" ;;
+  "uninstall")      reject_force; shift; cmd_uninstall "$@" ;;
+  "check")          reject_force; shift; cmd_check "$@" ;;
+  "status")         reject_force; shift; cmd_status "$@" ;;
+  "version")        reject_force; cmd_version ;;
+  "completion")     reject_force; shift; cmd_completion "$@" ;;
+  "-h" | "--help")  reject_force; cmd_help ;;
+  -*)
+    # Unknown option
+    cmd_help; exit 1
+    ;;
   *)
-    # Handle partial signoff contexts directly
-    if [[ "$1" == "-f" ]]; then
-      # Special case - forced signoff with no context
-      cmd_create -f
-    elif [[ "$1" == -* ]]; then
-      # Unknown option
-      cmd_help; exit 1
-    else
-      # Treat as partial signoff context(s)
-      cmd_create "$@"
-    fi
+    # Treat as partial signoff context(s)
+    cmd_create ${force:+-f} "$@"
     ;;
 esac

--- a/gh-signoff
+++ b/gh-signoff
@@ -531,7 +531,23 @@ _gh_signoff() {
       COMPREPLY=( $(compgen -W "create install uninstall check status version -f --help $contexts" -- "$cur") )
       return 0
       ;;
-    create|install|uninstall|check)
+    -f)
+      # A leading -f may be followed by the create command or a context;
+      # elsewhere only contexts remain
+      local contexts=$(_gh_signoff_contexts)
+      if [[ $COMP_CWORD -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "create $contexts" -- "$cur") )
+      else
+        COMPREPLY=( $(compgen -W "$contexts" -- "$cur") )
+      fi
+      return 0
+      ;;
+    create)
+      local contexts=$(_gh_signoff_contexts)
+      COMPREPLY=( $(compgen -W "$contexts" -- "$cur") )
+      return 0
+      ;;
+    install|uninstall|check)
       local contexts=$(_gh_signoff_contexts)
       COMPREPLY=( $(compgen -W "--branch $contexts" -- "$cur") )
       return 0

--- a/gh-signoff
+++ b/gh-signoff
@@ -25,6 +25,9 @@ fi
 # Cache for default branch
 DEFAULT_BRANCH=""
 
+# Reason the working tree failed is_clean, for error reporting
+UNCLEAN_REASON=""
+
 debug() {
   if [[ -n "$DEBUG" ]]; then
     echo "Debug: $*" >&2
@@ -78,16 +81,28 @@ is_clean() {
 
   if [[ -n "$($git_cmd status --porcelain)" ]]; then
     debug "found uncommitted changes"
+    UNCLEAN_REASON="repository has uncommitted changes"
     return 1
   fi
 
-  if ! $git_cmd rev-parse --abbrev-ref @{push} >/dev/null 2>&1; then
-    debug "no tracking branch found"
-    fail "current branch is not tracking a remote branch"
+  # @{push} is authoritative for "are my commits pushed?", but under
+  # push.default=simple it only resolves when local and upstream names match.
+  # Fall back to @{upstream}: HEAD contained in the upstream is a sound proxy
+  # for "this SHA is on the remote".
+  local push_ref
+  push_ref=$($git_cmd rev-parse --abbrev-ref @{push} 2>/dev/null) ||
+    push_ref=$($git_cmd rev-parse --abbrev-ref @{upstream} 2>/dev/null) ||
+    true
+
+  if [[ -z "$push_ref" ]]; then
+    debug "neither @{push} nor @{upstream} resolves"
+    UNCLEAN_REASON="current branch has no push destination or upstream (check push.default and branch tracking; -f to override)"
+    return 1
   fi
 
-  if [[ -n "$($git_cmd log @{push}..)" ]]; then
+  if [[ -n "$($git_cmd log "$push_ref"..)" ]]; then
     debug "found unpushed changes"
+    UNCLEAN_REASON="repository has unpushed changes"
     return 1
   fi
 
@@ -118,7 +133,7 @@ cmd_create() {
   done
 
   if ! $force && ! is_clean; then
-    fail "repository has uncommitted or unpushed changes"
+    fail "$UNCLEAN_REASON"
   fi
 
   local user

--- a/gh-signoff
+++ b/gh-signoff
@@ -76,6 +76,20 @@ get_signoff_contexts() {
   printf "%s\n" "${contexts[@]}"
 }
 
+# Push-rerouting config (pushRemote, pushDefault, push refspecs) can send
+# pushes somewhere other than the upstream remote, making @{upstream} an
+# unsound proxy for @{push}. Detect it rather than reimplement git's
+# push-routing rules.
+push_is_rerouted() {
+  local branch remote
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch=""
+  remote=$(git config "branch.${branch}.remote" 2>/dev/null) || remote=""
+
+  git config "branch.${branch}.pushRemote" >/dev/null 2>&1 ||
+    git config remote.pushDefault >/dev/null 2>&1 ||
+    { [[ -n "$remote" ]] && git config --get-all "remote.${remote}.push" >/dev/null 2>&1; }
+}
+
 is_clean() {
   local git_cmd=$(command -v git)
 
@@ -87,16 +101,19 @@ is_clean() {
 
   # @{push} is authoritative for "are my commits pushed?", but under
   # push.default=simple it only resolves when local and upstream names match.
-  # Fall back to @{upstream}: HEAD contained in the upstream is a sound proxy
-  # for "this SHA is on the remote".
+  # Fall back to @{upstream} — HEAD contained in the upstream is a sound proxy
+  # for "this SHA is on the remote" — but only in a centralized workflow
+  # where nothing reroutes pushes away from the upstream remote.
   local push_ref
-  push_ref=$($git_cmd rev-parse --abbrev-ref @{push} 2>/dev/null) ||
-    push_ref=$($git_cmd rev-parse --abbrev-ref @{upstream} 2>/dev/null) ||
-    true
+  push_ref=$($git_cmd rev-parse --abbrev-ref @{push} 2>/dev/null) || push_ref=""
+
+  if [[ -z "$push_ref" ]] && ! push_is_rerouted; then
+    push_ref=$($git_cmd rev-parse --abbrev-ref @{upstream} 2>/dev/null) || push_ref=""
+  fi
 
   if [[ -z "$push_ref" ]]; then
-    debug "neither @{push} nor @{upstream} resolves"
-    UNCLEAN_REASON="current branch has no push destination or upstream (check push.default and branch tracking; -f to override)"
+    debug "@{push} does not resolve and @{upstream} is not a sound fallback"
+    UNCLEAN_REASON="cannot verify the current branch is pushed (@{push} does not resolve; check push.default and branch tracking; -f to override)"
     return 1
   fi
 

--- a/gh-signoff
+++ b/gh-signoff
@@ -76,18 +76,25 @@ get_signoff_contexts() {
   printf "%s\n" "${contexts[@]}"
 }
 
-# Push-rerouting config (pushRemote, pushDefault, push refspecs) can send
-# pushes somewhere other than the upstream remote, making @{upstream} an
-# unsound proxy for @{push}. Detect it rather than reimplement git's
-# push-routing rules.
-push_is_rerouted() {
-  local branch remote
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch=""
-  remote=$(git config "branch.${branch}.remote" 2>/dev/null) || remote=""
+# @{upstream} is a sound stand-in for an unresolvable @{push} only in the
+# narrow centralized case: HEAD on a branch whose upstream lives on a real
+# remote, effective push.default simple (git's default), and nothing
+# rerouting pushes elsewhere. Every other push mode determines its
+# destination independently of the upstream — refuse rather than guess at
+# git's push-routing rules.
+upstream_fallback_is_safe() {
+  local branch remote push_default
+  branch=$(git symbolic-ref --short -q HEAD) || return 1
 
-  git config "branch.${branch}.pushRemote" >/dev/null 2>&1 ||
-    git config remote.pushDefault >/dev/null 2>&1 ||
-    { [[ -n "$remote" ]] && git config --get-all "remote.${remote}.push" >/dev/null 2>&1; }
+  push_default=$(git config push.default 2>/dev/null) || push_default="simple"
+  [[ "$push_default" == "simple" ]] || return 1
+
+  remote=$(git config "branch.${branch}.remote" 2>/dev/null) || return 1
+  [[ "$remote" != "." ]] || return 1
+
+  ! git config "branch.${branch}.pushRemote" >/dev/null 2>&1 &&
+    ! git config remote.pushDefault >/dev/null 2>&1 &&
+    ! git config --get-all "remote.${remote}.push" >/dev/null 2>&1
 }
 
 is_clean() {
@@ -102,12 +109,11 @@ is_clean() {
   # @{push} is authoritative for "are my commits pushed?", but under
   # push.default=simple it only resolves when local and upstream names match.
   # Fall back to @{upstream} — HEAD contained in the upstream is a sound proxy
-  # for "this SHA is on the remote" — but only in a centralized workflow
-  # where nothing reroutes pushes away from the upstream remote.
+  # for "this SHA is on the remote" — when that's provably safe.
   local push_ref
   push_ref=$($git_cmd rev-parse --abbrev-ref @{push} 2>/dev/null) || push_ref=""
 
-  if [[ -z "$push_ref" ]] && ! push_is_rerouted; then
+  if [[ -z "$push_ref" ]] && upstream_fallback_is_safe; then
     push_ref=$($git_cmd rev-parse --abbrev-ref @{upstream} 2>/dev/null) || push_ref=""
   fi
 

--- a/gh-signoff
+++ b/gh-signoff
@@ -83,7 +83,7 @@ get_signoff_contexts() {
 # destination independently of the upstream — refuse rather than guess at
 # git's push-routing rules.
 upstream_fallback_is_safe() {
-  local branch remote push_default
+  local branch remote push_default fetch_url push_url
   branch=$(git symbolic-ref --short -q HEAD) || return 1
 
   push_default=$(git config push.default 2>/dev/null) || push_default="simple"
@@ -91,6 +91,12 @@ upstream_fallback_is_safe() {
 
   remote=$(git config "branch.${branch}.remote" 2>/dev/null) || return 1
   [[ "$remote" != "." ]] || return 1
+
+  # Resolved URLs catch pushurl, pushInsteadOf rewrites, and multi-URL
+  # remotes: require exactly one fetch URL and one identical push URL
+  fetch_url=$(git remote get-url --all "$remote" 2>/dev/null) || return 1
+  push_url=$(git remote get-url --push --all "$remote" 2>/dev/null) || return 1
+  [[ "$fetch_url" == "$push_url" && "$fetch_url" != *$'\n'* ]] || return 1
 
   ! git config "branch.${branch}.pushRemote" >/dev/null 2>&1 &&
     ! git config remote.pushDefault >/dev/null 2>&1 &&

--- a/test/mocks/gh
+++ b/test/mocks/gh
@@ -27,6 +27,14 @@ if [[ -n "${GH_MOCK_DEBUG:-}" ]]; then
   echo "----------------------" >&2
 fi
 
+# --- Extension Proxy ---
+# gh runs extensions as subcommands: proxy 'gh signoff ...' to the
+# gh-signoff under test (used by completion's context lookup)
+if [[ "${1:-}" == "signoff" ]]; then
+  shift
+  exec gh-signoff "$@"
+fi
+
 # --- Argument Parsing & Mock Logic ---
 api_method="GET" # Default method
 api_path=""

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -344,9 +344,44 @@ add_bare_remote() {
   make_nested_repo
 
   run -1 gh-signoff
-  [[ "$output" == *"no push destination or upstream"* ]]
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
 
   run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "upstream fallback refuses when pushes are rerouted to another remote" {
+  # Triangular two-remote setup: upstream origin/main contains HEAD, but
+  # remote.pushDefault sends pushes to fork, whose ci/gate is not up to date.
+  # @{push} fails to resolve (fork/ci/gate was never fetched); falling back
+  # to the upstream would approve a SHA absent from the real push destination.
+  make_nested_repo
+  add_bare_remote
+  git push -q origin HEAD:main
+  git init -q --bare "$TEST_DIR/fork.git"
+  git remote add fork "$TEST_DIR/fork.git"
+  git checkout -q -b ci/gate
+  git branch -q --set-upstream-to=origin/main
+  git config push.default simple
+
+  git config remote.pushDefault fork
+  ! git rev-parse --abbrev-ref "@{push}" >/dev/null 2>&1
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  git config --unset remote.pushDefault
+
+  git config branch.ci/gate.pushRemote fork
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  git config --unset branch.ci/gate.pushRemote
+
+  git config remote.origin.push "refs/heads/*:refs/heads/qa/*"
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  git config --unset remote.origin.push
+
+  # With no rerouting config the fallback engages again
+  run -0 gh-signoff
   [[ "$output" == *"Signed off on"* ]]
 }
 

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -385,6 +385,39 @@ add_bare_remote() {
   [[ "$output" == *"Signed off on"* ]]
 }
 
+@test "upstream fallback refuses when fetch and push URLs differ" {
+  # remote.<name>.pushurl and url.*.pushInsteadOf send pushes to a different
+  # repository than fetches come from; multiple push URLs have no single
+  # destination. The upstream ref proves nothing about any of them.
+  make_nested_repo
+  add_bare_remote
+  git push -q origin HEAD:main
+  git init -q --bare "$TEST_DIR/fork.git"
+  git checkout -q -b ci/gate
+  git branch -q --set-upstream-to=origin/main
+  git config push.default simple
+
+  git config remote.origin.pushurl "$TEST_DIR/fork.git"
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  git config --unset remote.origin.pushurl
+
+  git config "url.$TEST_DIR/fork.git.pushInsteadOf" "$TEST_DIR/remote.git"
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  git config --remove-section "url.$TEST_DIR/fork.git"
+
+  git config remote.origin.pushurl "$TEST_DIR/remote.git"
+  git config --add remote.origin.pushurl "$TEST_DIR/fork.git"
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  git config --unset-all remote.origin.pushurl
+
+  # With fetch and push URLs identical again the fallback engages
+  run -0 gh-signoff
+  [[ "$output" == *"Signed off on"* ]]
+}
+
 @test "upstream fallback refuses unless effective push.default is simple" {
   # current would create the not-yet-existing origin/ci/gate; nothing and
   # matching have no single destination. In each, @{push} fails to resolve

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -361,6 +361,24 @@ add_bare_remote() {
   [[ "$output" == *"Signed off on"* ]]
 }
 
+# Leading -f dispatcher grammar tests
+@test "leading -f applies to contextual signoff" {
+  run -0 gh-signoff -f linux
+  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"for linux"* ]]
+}
+
+@test "leading -f with explicit create signs off on default context" {
+  run -0 gh-signoff -f create
+  [[ "$output" == *"Signed off on"* ]]
+  [[ ! "$output" == *"for"* ]]
+}
+
+@test "leading -f is rejected for non-create commands" {
+  run -1 gh-signoff -f status
+  [[ "$output" == *"-f is only valid for create"* ]]
+}
+
 @test "@{push} stays authoritative over upstream when both resolve" {
   # Triangular setup: feature tracks origin/main (which contains HEAD), but
   # push.default=current resolves @{push} to origin/feature, which lacks HEAD.

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -385,6 +385,44 @@ add_bare_remote() {
   [[ "$output" == *"Signed off on"* ]]
 }
 
+@test "upstream fallback refuses unless effective push.default is simple" {
+  # current would create the not-yet-existing origin/ci/gate; nothing and
+  # matching have no single destination. In each, @{push} fails to resolve
+  # and the upstream must not stand in for it.
+  make_nested_repo
+  add_bare_remote
+  git push -q origin HEAD:main
+  git checkout -q -b ci/gate
+  git branch -q --set-upstream-to=origin/main
+
+  for mode in current nothing matching; do
+    git config push.default "$mode"
+    ! git rev-parse --abbrev-ref "@{push}" >/dev/null 2>&1
+    run -1 gh-signoff
+    [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+  done
+
+  # The centralized renamed-branch case still succeeds
+  git config push.default simple
+  run -0 gh-signoff
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "upstream fallback refuses a purely local upstream" {
+  make_nested_repo
+  git branch -q base
+  git checkout -q -b ci/gate
+  git branch -q --set-upstream-to=base
+  git config push.default simple
+  [[ "$(git config branch.ci/gate.remote)" == "." ]]
+
+  run -1 gh-signoff
+  [[ "$output" == *"cannot verify the current branch is pushed"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
 @test "signoff fails with uncommitted changes message for dirty worktree" {
   make_nested_repo
   touch untracked-file

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -28,6 +28,23 @@ teardown() {
   [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
 }
 
+# Create a nested clean repository and cd into it. The top-level TEST_DIR repo
+# holds the untracked gh-signoff and gh mock binaries (still on PATH), which
+# would trip is_clean's uncommitted-changes check before the paths under test.
+make_nested_repo() {
+  git init -q "$TEST_DIR/repo"
+  cd "$TEST_DIR/repo"
+  git config user.name "Test User"
+  git commit --no-gpg-sign --allow-empty -m "Initial commit" >/dev/null
+  [[ -z "$(git status --porcelain)" ]]
+}
+
+# Add a bare remote to the nested repository
+add_bare_remote() {
+  git init -q --bare "$TEST_DIR/remote.git"
+  git remote add origin "$TEST_DIR/remote.git"
+}
+
 # Basic command tests
 @test "shows help with -h" {
   run -0 gh-signoff -h
@@ -290,4 +307,73 @@ teardown() {
   run -1 gh-signoff tests -f
   [[ "$output" == *"Failed to sign off on"*"for tests"* ]]
   unset MOCK_POST_STATUS_EXIT
+}
+
+# Cleanliness check tests (is_clean)
+@test "signoff succeeds via upstream fallback when @{push} does not resolve" {
+  # push.default=simple: @{push} fails for a branch whose name differs from
+  # its upstream's, but @{upstream} still proves HEAD is on the remote
+  make_nested_repo
+  add_bare_remote
+  git push -q origin HEAD:some-branch
+  git checkout -q -b ci/gate
+  git branch -q --set-upstream-to=origin/some-branch
+  git config push.default simple
+
+  run -0 gh-signoff
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "signoff via upstream fallback still catches unpushed changes" {
+  make_nested_repo
+  add_bare_remote
+  git push -q origin HEAD:some-branch
+  git checkout -q -b ci/gate
+  git branch -q --set-upstream-to=origin/some-branch
+  git config push.default simple
+  git commit --no-gpg-sign --allow-empty -m "Unpushed commit" >/dev/null
+
+  run -1 gh-signoff
+  [[ "$output" == *"unpushed changes"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "signoff fails with clear message when no push destination or upstream" {
+  make_nested_repo
+
+  run -1 gh-signoff
+  [[ "$output" == *"no push destination or upstream"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "signoff fails with uncommitted changes message for dirty worktree" {
+  make_nested_repo
+  touch untracked-file
+
+  run -1 gh-signoff
+  [[ "$output" == *"repository has uncommitted changes"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "@{push} stays authoritative over upstream when both resolve" {
+  # Triangular setup: feature tracks origin/main (which contains HEAD), but
+  # push.default=current resolves @{push} to origin/feature, which lacks HEAD.
+  # The upstream fallback must not engage.
+  make_nested_repo
+  add_bare_remote
+  git checkout -q -b feature
+  git push -q origin feature
+  git commit --no-gpg-sign --allow-empty -m "Second commit" >/dev/null
+  git push -q origin HEAD:main
+  git branch -q --set-upstream-to=origin/main
+  git config push.default current
+
+  run -1 gh-signoff
+  [[ "$output" == *"unpushed changes"* ]]
 }

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -361,6 +361,52 @@ add_bare_remote() {
   [[ "$output" == *"Signed off on"* ]]
 }
 
+# Completion tests for the leading -f grammar. Loads the generated completion
+# function and invokes it directly with a simulated command line.
+complete_words() {
+  eval "$(gh-signoff completion)"
+  COMP_WORDS=("$@" "")
+  COMP_CWORD=$#
+  COMPREPLY=()
+  _gh_signoff
+}
+
+@test "completion after leading -f offers create plus contexts" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_words gh-signoff -f
+  [[ " ${COMPREPLY[*]-} " == *" create "* ]]
+  [[ " ${COMPREPLY[*]-} " == *" linux "* ]]
+  [[ ! " ${COMPREPLY[*]-} " == *" status "* ]]
+  [[ ! " ${COMPREPLY[*]-} " == *" install "* ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
+}
+
+@test "completion after -f create offers contexts only" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_words gh-signoff -f create
+  [[ " ${COMPREPLY[*]-} " == *" linux "* ]]
+  [[ ! " ${COMPREPLY[*]-} " == *" create "* ]]
+  [[ ! " ${COMPREPLY[*]-} " == *" --branch "* ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
+}
+
+@test "completion after trailing -f offers contexts without create" {
+  export MOCK_BRANCH_PROTECTION_JSON='{"required_status_checks":{"contexts":["signoff/linux"]}}'
+  export MOCK_BRANCH_PROTECTION_EXIT=0
+
+  complete_words gh-signoff linux -f
+  [[ " ${COMPREPLY[*]-} " == *" linux "* ]]
+  [[ ! " ${COMPREPLY[*]-} " == *" create "* ]]
+
+  unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
+}
+
 # Leading -f dispatcher grammar tests
 @test "leading -f applies to contextual signoff" {
   run -0 gh-signoff -f linux


### PR DESCRIPTION
Closes #15.

Under `push.default=simple`, `@{push}` only resolves for branches whose name matches their upstream's. A CI gate worktree on a differently-named tracking branch — upstream configured, HEAD pushed — dead-ended at `is_clean()` with "current branch is not tracking a remote branch", blaming tracking config that was correct.

## is_clean(): @{upstream} fallback + real failure reasons

- `@{push}` stays authoritative for "are my commits pushed?". When it doesn't resolve, fall back to `@{upstream}` — HEAD contained in the upstream is a sound proxy for "this SHA is on the remote" — but only when that's provably safe. Review surfaced that an unresolvable `@{push}` is not exclusive to the centralized renamed-branch case: `remote.pushDefault` can target a never-fetched fork ref, `push.default=current` a not-yet-created branch, `nothing`/`matching` have no single destination, and a `.` upstream is purely local. Fetch and push URLs can also diverge: `remote.<name>.pushurl` and `url.*.pushInsteadOf` send pushes to a different repository than fetches come from, and multi-URL remotes have no single destination. The fallback is therefore an allowlist (`upstream_fallback_is_safe`): HEAD on a branch, effective `push.default` simple (git's default), upstream on a real remote (not `.`) whose single resolved push URL matches its fetch URL (via `git remote get-url`, which reflects `pushurl` and `pushInsteadOf`), and no `branch.<name>.pushRemote` / `remote.pushDefault` / push-refspec rerouting. Everything else refuses honestly rather than guessing at git's push-routing rules.
- `is_clean()` no longer `fail`s (exits) from inside the predicate. It reports why via `UNCLEAN_REASON` and returns nonzero, so the non-forced error names the real cause: uncommitted changes, unpushed changes, or "cannot verify the current branch is pushed" (with a pointer to `push.default` and `-f`).

While verifying the issue's claims on `e8bec483`: defect 1 (wrong message) reproduces; defect 2 (`-f` can't override) does not — `if ! $force && ! is_clean` short-circuits, so `-f` succeeded in every invocation form. The issue has been corrected at the source; the fail-inside-predicate protocol mix was a latent hazard, now removed.

## Dispatcher: explicit grammar for leading -f

Found adjacent to the above: the catch-all dispatcher case special-cased a bare leading `-f` by calling `cmd_create -f` and dropping all remaining args, so `gh signoff -f linux` silently signed off the *default* context. Now a leading `-f` is parsed before dispatch, matching help's `gh signoff [flags] [command] [options]`: it applies to create (explicit, implicit, or contextual) and is rejected with a clear error for every other command. Trailing `-f` unchanged. Completion follows the same grammar: a leading `-f` completes to `create` plus contexts; a trailing `-f` to contexts only.

## Tests

New bats cases run in a nested clean repository (the existing setup leaves the copied binaries untracked, which would trip the uncommitted-changes check first):

- upstream fallback succeeds without `-f` (the issue's exact scenario)
- fallback still catches unpushed changes; `-f` overrides
- no push destination or upstream → clear message; `-f` overrides
- dirty worktree → "uncommitted changes"; `-f` overrides
- triangular setup where `@{push}` and `@{upstream}` differ → `@{push}` wins
- two-remote triangular setup where `@{push}` doesn't resolve → fallback refused for each of `remote.pushDefault`, `branch.<name>.pushRemote`, and push refspecs; engages again once the rerouting config is removed
- fallback refused for `push.default` `current`, `nothing`, and `matching` (each with `@{push}` unresolvable as a precondition); the centralized renamed-branch case still succeeds
- fallback refused for a purely local `.` upstream; `-f` overrides
- fallback refused for `remote.origin.pushurl`, `url.*.pushInsteadOf`, and multiple push URLs; engages again once fetch and push URLs match
- leading `-f` grammar: `-f linux`, `-f create`, `-f status`
- completion: `-f <TAB>`, `-f create <TAB>`, trailing `-f <TAB>`

All 42 tests green under Bash 3, 4, and 5 (docker matrix). Also verified end-to-end with bare remotes and a mock `gh`: the issue's repro, the two-remote `remote.pushDefault` repro, and the `current`/`nothing`/`matching`/local-dot repros.
