### PR TITLE
Split the test matrix out of bin/ci

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -4,31 +4,21 @@ set -e
 # Directory containing this script
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$DIR")"
-DOCKER_DIR="$REPO_ROOT/test/docker"
 
-PASSED=true
+BASH_VERSIONS="3 4 5"
 
-for version in 3 4 5; do
-  echo -e "\n\033[1;35mBash $version\033[0m"
+# Tests first. bin/test has no side effects, so a red matrix stops here without
+# touching the commit's statuses.
+"$DIR/test" $BASH_VERSIONS
 
-  docker build --quiet --pull -t "gh-signoff-test:bash$version" \
-    --build-arg "BASH_VERSION=$version" \
-    -f "$DOCKER_DIR/Dockerfile" \
-    "$DOCKER_DIR" >/dev/null
-
-  if docker run --rm -v "$REPO_ROOT:/app" "gh-signoff-test:bash$version"; then
-    echo "✅ Tests passed for Bash $version"
-    ./gh-signoff "bash-$version" || true
-  else
-    echo "❌ Tests failed for Bash $version"
-    PASSED=false
-  fi
+# Then sign off, per Bash version and overall. No `|| true`: a swallowed signoff
+# failure leaves the commit with no statuses, which is indistinguishable from CI
+# never having run — and the usual cause, an unpushed commit, is exactly what
+# signoff exists to catch. Push, then run bin/ci.
+CONTEXTS=""
+for version in $BASH_VERSIONS; do
+  CONTEXTS="$CONTEXTS bash-$version"
 done
 
-if $PASSED; then
-  echo -e "\n✅ Tests passed for all Bash versions"
-  ./gh-signoff
-  exit 0
-else
-  exit 1
-fi
+"$REPO_ROOT/gh-signoff" $CONTEXTS
+"$REPO_ROOT/gh-signoff"

--- a/bin/ci
+++ b/bin/ci
@@ -5,6 +5,10 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$DIR")"
 
+# gh-signoff reads the repository from the current directory, not from its own
+# path, so signing off has to happen from the root however bin/ci was invoked
+cd "$REPO_ROOT"
+
 BASH_VERSIONS="3 4 5"
 
 # Tests first. bin/test has no side effects, so a red matrix stops here without

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+# Directory containing this script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$DIR")"
+DOCKER_DIR="$REPO_ROOT/test/docker"
+
+# Bash 3.2 is macOS's system bash, so it stays in the matrix long after everyone
+# else moved on. Name versions to narrow the run while iterating: bin/test 3
+VERSIONS="$*"
+[ -n "$VERSIONS" ] || VERSIONS="3 4 5"
+
+PASSED=true
+
+for version in $VERSIONS; do
+  echo -e "\n\033[1;35mBash $version\033[0m"
+
+  docker build --quiet --pull -t "gh-signoff-test:bash$version" \
+    --build-arg "BASH_VERSION=$version" \
+    -f "$DOCKER_DIR/Dockerfile" \
+    "$DOCKER_DIR" >/dev/null
+
+  if docker run --rm -v "$REPO_ROOT:/app" "gh-signoff-test:bash$version"; then
+    echo "✅ Tests passed for Bash $version"
+  else
+    echo "❌ Tests failed for Bash $version"
+    PASSED=false
+  fi
+done
+
+if $PASSED; then
+  # The per-version line above already said it when only one version ran
+  case "$VERSIONS" in
+    *" "*) echo -e "\n✅ Tests passed for Bash $VERSIONS" ;;
+  esac
+else
+  exit 1
+fi


### PR DESCRIPTION
`bin/ci` did two jobs — run the Bash 3/4/5 Docker matrix, and post signoff commit statuses to GitHub. This splits the matrix into `bin/test` and leaves `bin/ci` as "run the tests, then sign off".

### 1. `./gh-signoff "bash-$version" || true` swallowed failures

A signoff that failed — unpushed commit, `@{push}` not resolving, `gh` not authed — left CI green with no statuses on the commit, which is indistinguishable from CI never having run. And the usual cause, an unpushed commit, is exactly what signoff exists to catch.

The `|| true` is gone. Signoff failures fail the run.

### 2. No way to run just the tests

Running the matrix meant running `bin/ci`, which signs off as a side effect — so the correct sequence (run matrix → push → sign off) was impossible to follow without hand-copying the docker build/run loop, and running `bin/ci` before pushing signed off on a SHA GitHub doesn't have.

`bin/test` now runs the matrix and nothing else, exiting nonzero if any version fails. It takes optional versions to narrow the run while iterating:

```bash
bin/test        # Bash 3, 4, 5
bin/test 3      # just Bash 3
```

`bin/ci` calls it and signs off only once the whole matrix is green, so a red matrix stops before touching the commit's statuses.

**Behavior change worth flagging:** a partly green matrix now posts no per-version statuses at all, where it used to post them for the versions that passed. A `bash-3` status seems worth little when the run it belongs to is red — say the word if you'd rather keep the old granularity.

### 3. `./gh-signoff` was a relative path

`bin/ci` carefully computed `REPO_ROOT` and then invoked `./gh-signoff`, so it only worked from the repo root. Both scripts now use `$REPO_ROOT` throughout.

## Verification

Both scripts stay Bash 3.2-clean (`/bin/bash -n` under 3.2.57, no bash-4 features) and keep working under `set -e`.

Full matrix, counting `^not ok` per version:

```
bash 3: 0
bash 4: 0
bash 5: 0
```

`bin/test` run from an unrelated working directory (test lines elided):

```
Bash 3
1..42
✅ Tests passed for Bash 3

Bash 4
1..42
✅ Tests passed for Bash 4

Bash 5
1..42
✅ Tests passed for Bash 5

✅ Tests passed for Bash 3 4 5
```

Failure propagation, with `docker run` stubbed to fail:

```
Bash 3
not ok 1 pretend failure
❌ Tests failed for Bash 3
...
bin/test exit status: 1
```

`bin/ci` wiring, with `bin/test` and `gh-signoff` stubbed so nothing is posted to GitHub:

```
--- case 1: tests pass ---
STUB bin/test called with: 3 4 5
STUB gh-signoff called with: [bash-3 bash-4 bash-5]
STUB gh-signoff called with: []
bin/ci exit: 0
--- case 2: tests fail ---
STUB bin/test called with: 3 4 5
bin/ci exit: 1
--- case 3: signoff fails ---
STUB bin/test called with: 3 4 5
STUB gh-signoff called with: [bash-3 bash-4 bash-5]
bin/ci exit: 1
```

Case 2 confirms a red matrix posts nothing; case 3 confirms a failed signoff is no longer swallowed. All three ran from `/` rather than the repo root.
