### PR TITLE
Don't leak an internal error when check reports no signoff requirement

### DIFF
--- a/gh-signoff
+++ b/gh-signoff
@@ -10,6 +10,9 @@ export STATUS_SUCCESS="✓"
 export STATUS_PENDING="⟳"
 export STATUS_FAILURE="✗"
 
+# Catches failures the script didn't anticipate. Commands report an expected
+# negative result (e.g. check on an unprotected branch) by exiting nonzero
+# themselves: returning nonzero would reach this trap and look unexpected.
 trap 'fail "Unexpected error on line $LINENO ($?)"' ERR
 
 if ! command -v git >/dev/null 2>&1; then
@@ -399,7 +402,7 @@ cmd_check() {
         echo "${STATUS_FAILURE} GitHub ${branch} branch does not require signoff on ${context}"
       fi
     done
-    return 1
+    exit 1
   }
 
   # Check each context
@@ -464,7 +467,7 @@ cmd_status() {
   local statuses
   statuses=$(gh api "repos/:owner/:repo/commits/${sha}/status" 2>/dev/null) || {
     echo "${STATUS_FAILURE} Could not get status for commit ${sha}"
-    return 1
+    exit 1
   }
 
   # Create required contexts list - always start with "signoff"

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -143,6 +143,20 @@ add_bare_remote() {
   unset MOCK_BRANCH_PROTECTION_JSON MOCK_BRANCH_PROTECTION_EXIT
 }
 
+# Exact output, not substring: bats folds stderr into $output, so a leaked
+# internal diagnostic (e.g. the ERR trap firing on the command's own nonzero
+# exit) is invisible to a substring assertion.
+@test "check reports only the negative result for an unprotected branch" {
+  # Mock: no protection at all (like a 404 from the protection API)
+  export MOCK_BRANCH_PROTECTION_EXIT=1
+
+  run -1 gh-signoff check
+  [[ "$output" == "${STATUS_FAILURE} GitHub main branch does not require signoff" ]] || return 1
+
+  run -1 gh-signoff check windows
+  [[ "$output" == "${STATUS_FAILURE} GitHub main branch does not require signoff on windows" ]]
+}
+
 @test "uninstall with context removes contextual protection" {
   # Expect DELETE protection call to succeed
   export MOCK_DELETE_PROTECTION_EXIT=0
@@ -274,6 +288,17 @@ add_bare_remote() {
   [[ "$output" == *"Could not get status for commit"* ]]
 
   unset MOCK_COMMIT_STATUS_EXIT
+}
+
+# Exact output, for the same reason as the check test above
+@test "status reports only the negative result when the status API fails" {
+  # Mock: Commit status API fails
+  export MOCK_COMMIT_STATUS_EXIT=1
+  local sha
+  sha=$(git rev-parse HEAD)
+
+  run -1 gh-signoff status
+  [[ "$output" == "${STATUS_FAILURE} Could not get status for commit ${sha}" ]]
 }
 
 @test "completion --contexts returns signoff contexts" {


### PR DESCRIPTION
Found while smoke-testing #14. This is a pre-existing bug on `main`, unrelated to and independent of #14 — it needs no coordination with that PR.

## The bug

`gh signoff check` on a branch with no protection — the common case for any unprotected repo — prints its correct result and then leaks an internal diagnostic:

```
$ GH_REPO=YukiWorks432/gh-signoff gh signoff check --branch main
✗ GitHub main branch does not require signoff
Error: Unexpected error on line 674 (1)
```

`cmd_check` ends that path with `return 1`. Nonzero propagates out to the top-level `case` dispatch — a command in the script's own body — which trips the script-wide `trap 'fail "Unexpected error on line $LINENO ($?)"' ERR`. Line 674 is the `"check")` dispatch arm.

`cmd_status` has the same shape on its `✗ Could not get status for commit ...` path, and trips the trap identically (line 675). Those two were the whole class: they are the only `cmd_*` functions that return nonzero to the dispatch rather than exiting.

## The fix

Exit nonzero from the command instead of returning, which is what `cmd_create` already does for its failed-signoff path. The `✗` message and the nonzero exit status — meaningful for `gh signoff check && ...` — are unchanged; only the bogus `Error:` line goes away. The ERR trap stays and keeps guarding genuinely unexpected failures; a comment at the trap records the invariant so the next command doesn't reintroduce it.

### Why not fix it at the dispatch

The tempting one-line, whole-class fix is `esac || exit $?` (or `|| exit $?` per arm). It does silence the trap and propagate the status, but it puts the commands inside an AND-OR list, and bash disables `errexit` for the **entire dynamic extent** of a command in that position — including inside the called function. An unhandled failure anywhere in `cmd_create`/`cmd_install`/etc. would then continue with bad state instead of aborting. Verified on bash 3.2 and 5.3:

```bash
set -euo pipefail
f() { false; echo "ERREXIT-DISABLED: continued after failure"; }
case x in x) f ;; esac || exit $?
# prints ERREXIT-DISABLED on both 3.2 and 5.3
```

Trading a cosmetic leak for a silently weakened `set -e` across every command isn't worth it. Also worth noting: the script doesn't `set -E`, so the ERR trap is never inherited into functions — a real internal failure aborts inside the function via errexit and never reaches the trap at all. The trap's only live trigger today was the intentional `return 1`s this PR removes.

## Why the existing tests missed it

bats merges stderr into `$output`, and the existing assertions are substrings:

```bash
[[ "$output" == *"does not require signoff"* ]]
```

The extra `Error: ...` line satisfies that just fine. The two new tests assert **exact** output, so any leaked diagnostic fails them.

Also note the assertions are written to be the last command in the test body (or `|| return 1`): on bash 3.2 a failing `[[ ]]` inside a bats test function does not trip `set -e`, so a trailing command — even a `unset` — becomes the test's status and silently disarms the assertion. Empirically confirmed: `[[ "a" == "b" ]]` followed by `unset FOO` PASSES on bash 3.2 and fails on bash 4/5. (bats runs each test in its own process, so the trailing `unset`s elsewhere in this file are unnecessary anyway.)

## Verification

- `bash -n gh-signoff` clean.
- Full bats suite in the Dockerized bash 3, 4 and 5 images: **42 passing before, 44 passing after** (2 new tests), zero failures on all three versions.
- **Negative check** — the important one. Reverted just the two `exit 1`s back to `return 1` in a scratch copy and reran all three images. Exactly the two new tests fail, on every version:

  | bash | result with fix reverted |
  |---|---|
  | 3 | `not ok 13 check reports only the negative result for an unprotected branch`, `not ok 25 status reports only the negative result when the status API fails` (42/44) |
  | 4 | same two failures (42/44) |
  | 5 | same two failures (42/44) |

- Live re-check against real repos (read-only), both clean, still exit 1:

```
$ GH_REPO=YukiWorks432/gh-signoff ./gh-signoff check --branch main
✗ GitHub main branch does not require signoff
exit=1

$ GH_REPO=basecamp/gh-signoff ./gh-signoff check --branch main
✗ GitHub main branch does not require signoff
exit=1
```

`bin/ci` was deliberately not run — it POSTs real signoff statuses to this repo rather than just reviewing.
