### PR TITLE
Retry teardown cleanup instead of reporting phantom test failures

### DIFF
--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -24,8 +24,38 @@ setup() {
   git commit --no-gpg-sign --allow-empty -m "Initial commit" >/dev/null
 }
 
+# Remove the test's scratch repositories, tolerating concurrent writers.
+#
+# Every test builds real git repositories under TEST_DIR, and plenty of things
+# write into a git repository behind our back: trace2 event daemons, fsmonitor,
+# background `git maintenance` jobs, editor and IDE git integrations, file
+# indexers (Spotlight/mds) and antivirus scanners. Any of them can drop a file
+# into a directory rm is midway through emptying, and rm then fails with
+# "Directory not empty". Left unhandled that makes teardown return nonzero and
+# bats reports the test as failed with every assertion having passed — a
+# different test each run, which is what makes it so confusing to chase.
+#
+# So retry, briefly and a bounded number of times: these writers arrive in a
+# short burst once the last git command exits, so a second attempt almost
+# always wins. Do not replace this with a bare `rm -rf`.
+#
+# Exhausting the retries warns rather than fails. A leaked directory under
+# TMPDIR is cheap and visible; a suite that reports phantom failures is not,
+# and teardown has no business deciding whether a test passed. The warning
+# goes to bats' terminal descriptor so a persistent leak still gets noticed.
 teardown() {
-  [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+  local attempt=0
+
+  while [ -d "$TEST_DIR" ] && ! rm -rf "$TEST_DIR" 2>/dev/null; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 10 ]; then
+      echo "# warning: could not remove $TEST_DIR, leaving it behind" >&3
+      break
+    fi
+    sleep 0.1
+  done
+
+  return 0
 }
 
 # Create a nested clean repository and cd into it. The top-level TEST_DIR repo


### PR DESCRIPTION
## The problem

`test/signoff.bats` teardown was a bare `rm -rf`:

```bash
teardown() {
  [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
}
```

Every test builds one or more real git repositories under a `mktemp -d`. If
anything writes into those repositories while `rm` is emptying them, `rm` fails
with "Directory not empty", teardown returns nonzero, and **bats reports the
test as failed even though every assertion passed**. The failure message points
at the teardown line, so it reads as a defect in the test rather than in the
cleanup.

## Diagnosis

A `~/.gitconfig` containing

```
trace2.eventtarget = af_unix:stream:/Users/…/.git-ai/internal/daemon/trace2.sock
```

hands every git invocation to a background daemon, which then writes into the
repo *asynchronously, after git has exited* — racing teardown. Leftovers
recovered from failed runs:

```
tmp.XXXX/.git/fast_import_crash_99660
tmp.XXXX/.git/objects/pack/tmp_idx_9UZndD
tmp.XXXX/.git/objects/pack/pack-….keep
tmp.XXXX/.git/ai/working_logs/initial
tmp.XXXX/remote.git/ai/logs
```

Cost was one to three failures per full-suite run, **on a different set of tests
each time** — the signature of a race rather than a bug.

trace2 is just one member of the class. `core.fsmonitor` daemons, background
`git maintenance` jobs, editor and IDE git integrations, file indexers
(Spotlight/mds), and antivirus scanners all write into a repository out of band.
Any contributor running one sees the same phantom failures. Note that CI never
does — the docker images have no such daemon — so this only ever bites locally,
which is exactly what makes it look like the developer's fault.

## The fix

A bounded retry: up to 10 attempts, 0.1s apart (~0.9s ceiling). These writers
arrive in a short burst once the last git command exits, so the second attempt
almost always wins.

Two deliberate choices, both explained in the comment so the next reader doesn't
"simplify" it back:

- **Exhausting the retries warns and returns 0 rather than failing.** A leaked
  directory under `TMPDIR` is cheap, visible, and swept up by the system; a
  suite that cries wolf is neither. Teardown governs cleanup, not whether a test
  passed. The warning goes to bats' terminal descriptor (`>&3`) so a persistent
  leak still gets noticed rather than accumulating silently.
- **The loop is bounded and cheap.** In the common case the body never executes,
  so the retry costs exactly what the old one-liner cost.

`make_nested_repo`, `add_bare_remote`, and the `fork.git` setups all create
their repos *inside* `$TEST_DIR`, so the single `rm -rf` already covers them —
no separate treatment needed.

This also drops a latent bug in the old one-liner: when `TEST_DIR` was already
gone, `[ -d "$TEST_DIR" ] && rm -rf` returned 1 and failed the test on its own.

## Proof — the real thing, not a simulation

The machine this was developed on has that daemon live:

```
$ git config --global --get trace2.eventtarget
af_unix:stream:/Users/jeremy/.git-ai/internal/daemon/trace2.sock
```

Alternating the old and new teardown on the real suite, same machine, same
session:

```
before run 1: 41 ok, 1 not ok
    not ok 2 shows version
after  run 1: 42 ok, 0 not ok
before run 2: 41 ok, 1 not ok
    not ok 14 install with branch and context arguments
after  run 2: 42 ok, 0 not ok
before run 3: 41 ok, 1 not ok
    not ok 42 @{push} stays authoritative over upstream when both resolve
after  run 3: 42 ok, 0 not ok
```

Note the failing test is **different every run** — tests 2, 14, 42 — while every
assertion in them passed. Verbatim:

```
not ok 14 install with branch and context arguments
# (from function `teardown' in test file test/signoff.bats, line 28)
#   `[ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"' failed
# rm: /var/folders/…/T/tmp.46fAWf9ff0/.git/objects: Directory not empty
# rm: /var/folders/…/T/tmp.46fAWf9ff0/.git: Directory not empty

not ok 29 signoff via upstream fallback still catches unpushed changes
# (from function `teardown' in test file test/signoff.bats, line 28)
#   `[ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"' failed
# rm: /var/folders/…/T/tmp.iJqXbubDgy/repo/.git: Directory not empty
# rm: /var/folders/…/T/tmp.iJqXbubDgy/repo: Directory not empty
```

Six more consecutive runs with the fix, on the same daemon-afflicted machine —
and zero give-up warnings, meaning the retries always won well inside budget:

```
after run 1: 42 ok, 0 not ok, warnings: 0
after run 2: 42 ok, 0 not ok, warnings: 0
after run 3: 42 ok, 0 not ok, warnings: 0
after run 4: 42 ok, 0 not ok, warnings: 0
after run 5: 42 ok, 0 not ok, warnings: 0
after run 6: 42 ok, 0 not ok, warnings: 0
```

Nine clean runs after, three-for-three failures before.

## Proof — the two properties that matter

A synthetic harness pins down the edges the live daemon can't be asked to
reproduce on demand. A background subshell hammers
`.git/objects/pack/tmp_idx_*`, `.git/ai/working_logs/…` and
`.git/fast_import_crash_*` into `$TEST_DIR` while the test's assertions all
pass.

**A real assertion failure still fails.** This is the "did you paper over
failures?" check:

```
1..3
ok 1 new teardown: writer burst races rm -rf (assertions all pass)
ok 2 new teardown: writer outlives the retry budget
not ok 3 new teardown: a real assertion failure still fails
# (in test file new.bats, line 36)
#   `[[ "$output" == "this will never match" ]]' failed
```

The same harness under the old teardown fails 5/5 runs on test 1 alone.

**The give-up path warns, passes, and stays bounded.** Forced with a
permanently unremovable directory so the retries are guaranteed to be exhausted:

```
1..1
# warning: could not remove /var/folders/…/T/tmp.EaPxbKXDNO, leaving it behind
ok 1 give-up path: permanently unremovable dir warns, passes, stays bounded
real 1.38
```

## Verification

Full matrix, `grep -c '^not ok'` per the repo's docker harness — all zero, 42/42
passing on each:

| Image | `not ok` count |
|---|---|
| `gh-signoff-test:bash3` | 0 |
| `gh-signoff-test:bash4` | 0 |
| `gh-signoff-test:bash5` | 0 |

Bash 3.2 compatible: no bash-4+ syntax, and fractional `sleep` works under both
macOS `/bin/sleep` and the images' busybox `sleep`.

## Timing

Interleaved before/after, five pairs on bash 5 (all runs 42 ok, 0 not ok):

```
run 1: before=3.00s  after=2.99s
run 2: before=2.85s  after=2.88s
run 3: before=2.90s  after=3.13s
run 4: before=2.92s  after=3.14s
run 5: before=3.41s  after=3.54s
```

The delta is inside run-to-run variance (the *before* runs alone span
2.85–3.41s). Isolating teardown itself over 500 iterations of a removable
scratch repo confirms it:

```
old_teardown: 6.471s total, 12.942 ms/teardown
new_teardown: 6.672s total, 13.343 ms/teardown
old_teardown: 8.639s total, 17.278 ms/teardown
new_teardown: 7.119s total, 14.237 ms/teardown
```

`mktemp`/`mkdir` dominate; the retry loop is free in the happy path because its
body never runs.
