### PR TITLE
Sign off on a branch checked out from a fork pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ gh signoff
 
 Without `-f`, signoff requires HEAD to be contained in `@{push}`. When `@{push}` doesn't resolve, signoff falls back to `@{upstream}` only in the narrow centralized case — `push.default` simple (or unset), an upstream on a real remote whose single push URL matches its fetch URL, and no `pushRemote`/`pushDefault`/push-refspec rerouting — and otherwise refuses. CI worktrees that check out a differently-named tracking branch may want `git config push.default upstream`.
 
+A branch checked out from a cross-repository pull request (`gh pr checkout` on a fork PR) tracks a bare URL rather than a named remote, so it has no tracking ref for either `@{push}` or `@{upstream}` to resolve. Signoff asks that repository directly instead — one `git ls-remote` for the tracked ref — and accepts HEAD when it's contained in the advertised tip. If that tip isn't already in your repository, or a push wouldn't provably land on the same URL, it refuses rather than guess.
+
 ### To require signoff for PR merges
 
 ```bash

--- a/gh-signoff
+++ b/gh-signoff
@@ -31,6 +31,9 @@ DEFAULT_BRANCH=""
 # Reason the working tree failed is_clean, for error reporting
 UNCLEAN_REASON=""
 
+# Tip SHA url_remote_tip proved, for is_clean to check HEAD against
+URL_REMOTE_TIP=""
+
 debug() {
   if [[ -n "$DEBUG" ]]; then
     echo "Debug: $*" >&2
@@ -110,6 +113,117 @@ upstream_fallback_is_safe() {
     ! git config --get-all "remote.${remote}.push" >/dev/null 2>&1
 }
 
+# git accepts either a remote name or a URL wherever a remote is named, so
+# branch.<name>.remote may hold either. Distinguish them by enumeration rather
+# than by pattern: a value that matches a configured remote is a name, and
+# everything else git treats as a URL.
+remote_is_named() {
+  local remote="$1" name found=1
+
+  while read -r name; do
+    if [[ "$name" == "$remote" ]]; then
+      found=0
+    fi
+  done < <(git remote)
+
+  return "$found"
+}
+
+# `gh pr checkout` on a cross-repository (fork) pull request creates no named
+# remote. It points the branch at a bare URL instead:
+#
+#   branch.<name>.remote     = https://github.com/someone/gh-signoff.git
+#   branch.<name>.pushremote = https://github.com/someone/gh-signoff.git
+#   branch.<name>.merge      = refs/heads/<their-branch>
+#
+# git supports that natively, but a URL-valued remote has no remote-tracking
+# ref, so every local check dead-ends: @{push} and @{upstream} both fail with
+# "not stored as a remote-tracking branch", and upstream_fallback_is_safe's
+# `git remote get-url` errors with "No such remote '<url>'". Reviewing a
+# contributor's pull request and signing off on it is a core workflow for this
+# tool, so rather than refuse for want of a local ref, ask the remote itself.
+#
+# `git ls-remote <url> <ref>` advertises that ref's tip SHA. A repository
+# holding a commit holds all of its ancestors, and a commit's parents are part
+# of the object, so ancestry computed locally is ancestry on the remote too:
+# once the tip object is present here, "HEAD is contained in the tip" proves
+# HEAD is on that remote. That is precisely the inference is_clean already
+# makes about a remote-tracking ref — the tip SHA merely arrives over the wire
+# instead of from refs/remotes. When the tip object is absent locally there is
+# nothing to reason from: ls-remote yields ref tips, not history, so proving
+# containment would mean fetching. Refuse instead.
+#
+# Which repository we are proving things about still has to be the one a push
+# would reach, so the routing allowlist mirrors upstream_fallback_is_safe:
+# effective push.default simple, and the effective push remote this same URL.
+# Push refspecs need no check here — a [remote "<url>"] config section would
+# make the URL a configured remote, which remote_is_named already excludes.
+# url.*.pushInsteadOf does need one: it rewrites push URLs, and git offers no
+# way to expand the push side of an anonymous remote (`git remote get-url
+# --push` insists on a configured remote), so refuse rather than interrogate a
+# URL that a push would not use.
+#
+# Returns 0 with URL_REMOTE_TIP set to the proven tip, 1 with UNCLEAN_REASON
+# set when the branch tracks a URL but nothing can be proven about it, and 2
+# when the branch does not track a URL at all and the caller's own reason
+# should stand.
+url_remote_tip() {
+  local branch remote merge_ref push_default push_remote advertised sha ref
+
+  branch=$(git symbolic-ref --short -q HEAD) || return 2
+  remote=$(git config "branch.${branch}.remote" 2>/dev/null) || return 2
+  [[ -n "$remote" && "$remote" != "." ]] || return 2
+  ! remote_is_named "$remote" || return 2
+
+  # Past here the branch provably tracks a URL, so failures say so instead of
+  # deferring to is_clean's generic "check push.default and branch tracking"
+  URL_REMOTE_TIP=""
+
+  merge_ref=$(git config "branch.${branch}.merge" 2>/dev/null) || merge_ref=""
+  # git resolves an unqualified merge ref against the remote's heads
+  [[ -z "$merge_ref" || "$merge_ref" == refs/* ]] || merge_ref="refs/heads/${merge_ref}"
+
+  push_default=$(git config push.default 2>/dev/null) || push_default="simple"
+  push_remote=$(git config "branch.${branch}.pushRemote" 2>/dev/null) ||
+    push_remote=$(git config remote.pushDefault 2>/dev/null) ||
+    push_remote="$remote"
+
+  if [[ -z "$merge_ref" || "$push_default" != "simple" || "$push_remote" != "$remote" ]] ||
+    git config --get-regexp '^url\..*\.pushinsteadof$' >/dev/null 2>&1; then
+    debug "branch ${branch} tracks the URL ${remote} but its push destination is not provably that URL"
+    UNCLEAN_REASON="cannot verify the current branch is pushed (branch ${branch} tracks ${remote} as a URL, so there is no tracking ref, and its push destination is not provably that URL; add a named remote for it, or -f to override)"
+    return 1
+  fi
+
+  advertised=$(git ls-remote "$remote" "$merge_ref" 2>/dev/null) || {
+    debug "could not reach ${remote} to look up ${merge_ref}"
+    UNCLEAN_REASON="cannot verify the current branch is pushed (branch ${branch} tracks ${remote} as a URL, so there is no tracking ref, and that remote could not be reached; -f to override)"
+    return 1
+  }
+
+  # ls-remote patterns match ref tails, so take the exact ref rather than the
+  # first line
+  while IFS=$'\t' read -r sha ref; do
+    if [[ "$ref" == "$merge_ref" ]]; then
+      URL_REMOTE_TIP="$sha"
+    fi
+  done <<<"$advertised"
+
+  if [[ -z "$URL_REMOTE_TIP" ]]; then
+    debug "${merge_ref} is not advertised by ${remote}"
+    UNCLEAN_REASON="repository has unpushed changes (${merge_ref} does not exist on ${remote})"
+    return 1
+  fi
+
+  if ! git cat-file -e "${URL_REMOTE_TIP}^{commit}" 2>/dev/null; then
+    debug "${remote} advertises ${merge_ref} at ${URL_REMOTE_TIP}, which is not in this repository"
+    UNCLEAN_REASON="cannot verify the current branch is pushed (${remote} has ${merge_ref} at ${URL_REMOTE_TIP}, which is not in this repository; git fetch ${remote} ${merge_ref}, or -f to override)"
+    return 1
+  fi
+
+  return 0
+}
+
 is_clean() {
   local git_cmd=$(command -v git)
 
@@ -126,8 +240,19 @@ is_clean() {
   local push_ref
   push_ref=$($git_cmd rev-parse --abbrev-ref @{push} 2>/dev/null) || push_ref=""
 
-  if [[ -z "$push_ref" ]] && upstream_fallback_is_safe; then
-    push_ref=$($git_cmd rev-parse --abbrev-ref @{upstream} 2>/dev/null) || push_ref=""
+  if [[ -z "$push_ref" ]]; then
+    if upstream_fallback_is_safe; then
+      push_ref=$($git_cmd rev-parse --abbrev-ref @{upstream} 2>/dev/null) || push_ref=""
+    else
+      # Neither ref resolves for a branch tracking a bare URL, which has no
+      # remote-tracking ref at all: ask that remote for the tip instead
+      local tip_status=0
+      url_remote_tip || tip_status=$?
+      case "$tip_status" in
+        0) push_ref="$URL_REMOTE_TIP" ;;
+        1) return 1 ;;
+      esac
+    fi
   fi
 
   if [[ -z "$push_ref" ]]; then

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -571,9 +571,9 @@ checkout_fork_pull_request() {
   make_nested_repo
   checkout_fork_pull_request
 
-  ! git rev-parse --abbrev-ref "@{push}" >/dev/null 2>&1
-  ! git rev-parse --abbrev-ref "@{upstream}" >/dev/null 2>&1
-  ! git remote get-url --all "$TEST_DIR/fork.git" >/dev/null 2>&1
+  ! git rev-parse --abbrev-ref "@{push}" >/dev/null 2>&1 || return 1
+  ! git rev-parse --abbrev-ref "@{upstream}" >/dev/null 2>&1 || return 1
+  ! git remote get-url --all "$TEST_DIR/fork.git" >/dev/null 2>&1 || return 1
 
   run -0 gh-signoff
   [[ "$output" == *"Signed off on"* ]] || return 1

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -92,6 +92,26 @@ add_bare_remote() {
   git remote add origin "$TEST_DIR/remote.git"
 }
 
+# Configure the current branch the way `gh pr checkout` configures a branch
+# taken from a cross-repository (fork) pull request: no named remote, just a
+# URL (git accepts a path here identically) and the head ref it tracks
+track_url_remote() {
+  local url="$1" ref="$2" branch
+  branch=$(git symbolic-ref --short HEAD)
+  git config "branch.${branch}.remote" "$url"
+  git config "branch.${branch}.pushremote" "$url"
+  git config "branch.${branch}.merge" "$ref"
+}
+
+# Stand up a bare repository playing the contributor's fork, with the pull
+# request's head branch at HEAD, and track it by URL from the current branch
+checkout_fork_pull_request() {
+  git init -q --bare "$TEST_DIR/fork.git"
+  git push -q "$TEST_DIR/fork.git" HEAD:refs/heads/their-branch
+  git checkout -q -b their-branch
+  track_url_remote "$TEST_DIR/fork.git" refs/heads/their-branch
+}
+
 # Basic command tests
 @test "shows help with -h" {
   run -0 gh-signoff -h
@@ -542,6 +562,130 @@ add_bare_remote() {
 
   run -0 gh-signoff -f
   [[ "$output" == *"Signed off on"* ]] || return 1
+}
+
+@test "signoff succeeds on a branch checked out from a fork pull request" {
+  # A URL-valued remote has no remote-tracking ref, so neither @{push} nor
+  # @{upstream} resolves and `git remote get-url` has no remote to look up.
+  # The fork itself is the only witness that HEAD is published.
+  make_nested_repo
+  checkout_fork_pull_request
+
+  ! git rev-parse --abbrev-ref "@{push}" >/dev/null 2>&1
+  ! git rev-parse --abbrev-ref "@{upstream}" >/dev/null 2>&1
+  ! git remote get-url --all "$TEST_DIR/fork.git" >/dev/null 2>&1
+
+  run -0 gh-signoff
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "fork pull request signoff accepts a commit contained in the fork's tip" {
+  # The tip object is here, so its ancestry is checkable locally, and a
+  # repository holding a commit holds every ancestor of it
+  make_nested_repo
+  git checkout -q -b their-branch
+  git commit --no-gpg-sign --allow-empty -m "Their newer commit" >/dev/null
+  git init -q --bare "$TEST_DIR/fork.git"
+  git push -q "$TEST_DIR/fork.git" HEAD:refs/heads/their-branch
+  git reset -q --hard HEAD^
+  track_url_remote "$TEST_DIR/fork.git" refs/heads/their-branch
+
+  run -0 gh-signoff
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "fork pull request signoff still catches unpushed changes" {
+  make_nested_repo
+  checkout_fork_pull_request
+  git commit --no-gpg-sign --allow-empty -m "Unpushed commit" >/dev/null
+
+  run -1 gh-signoff
+  [[ "$output" == *"unpushed changes"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "fork pull request signoff refuses when the fork's tip is not in this repository" {
+  # ls-remote advertises ref tips, not history: with the tip object absent
+  # there is nothing to compute containment against, and proving HEAD is on
+  # the fork would mean fetching
+  make_nested_repo
+  checkout_fork_pull_request
+  git clone -q --branch their-branch "$TEST_DIR/fork.git" "$TEST_DIR/contributor"
+  git -C "$TEST_DIR/contributor" config user.name "Contributor"
+  git -C "$TEST_DIR/contributor" commit --no-gpg-sign --allow-empty -m "Their newer commit" >/dev/null
+  git -C "$TEST_DIR/contributor" push -q origin HEAD:refs/heads/their-branch
+
+  run -1 gh-signoff
+  [[ "$output" == *"which is not in this repository"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "fork pull request signoff refuses when the tracked ref is absent from the fork" {
+  make_nested_repo
+  checkout_fork_pull_request
+  git config branch.their-branch.merge refs/heads/never-pushed
+
+  run -1 gh-signoff
+  [[ "$output" == *"unpushed changes"* ]]
+  [[ "$output" == *"refs/heads/never-pushed does not exist"* ]]
+}
+
+@test "fork pull request signoff refuses when the fork cannot be reached" {
+  make_nested_repo
+  checkout_fork_pull_request
+  track_url_remote "$TEST_DIR/no-such-fork.git" refs/heads/their-branch
+
+  run -1 gh-signoff
+  [[ "$output" == *"could not be reached"* ]]
+
+  run -0 gh-signoff -f
+  [[ "$output" == *"Signed off on"* ]]
+}
+
+@test "fork pull request signoff refuses when the push destination is not that URL" {
+  # Proving HEAD is on the fork says nothing if a push would land elsewhere,
+  # so the same routing allowlist as the @{upstream} fallback applies
+  make_nested_repo
+  checkout_fork_pull_request
+  git init -q --bare "$TEST_DIR/elsewhere.git"
+
+  for mode in current nothing matching; do
+    git config push.default "$mode"
+    run -1 gh-signoff
+    [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  done
+  git config push.default simple
+
+  git config branch.their-branch.pushremote "$TEST_DIR/elsewhere.git"
+  run -1 gh-signoff
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  git config branch.their-branch.pushremote "$TEST_DIR/fork.git"
+
+  git config remote.pushDefault "$TEST_DIR/elsewhere.git"
+  git config --unset branch.their-branch.pushremote
+  run -1 gh-signoff
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  git config --unset remote.pushDefault
+
+  # url.*.pushInsteadOf rewrites push URLs, and git offers no way to expand
+  # the push side of an anonymous remote to compare against
+  git config "url.$TEST_DIR/elsewhere.git.pushInsteadOf" "$TEST_DIR/fork.git"
+  run -1 gh-signoff
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  git config --remove-section "url.$TEST_DIR/elsewhere.git"
+
+  git config --unset branch.their-branch.merge
+  run -1 gh-signoff
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  git config branch.their-branch.merge refs/heads/their-branch
+
+  # With nothing rerouting the push away from the tracked URL, the proof engages
+  run -0 gh-signoff
+  [[ "$output" == *"Signed off on"* ]]
 }
 
 @test "signoff fails with uncommitted changes message for dirty worktree" {

--- a/test/signoff.bats
+++ b/test/signoff.bats
@@ -576,7 +576,7 @@ checkout_fork_pull_request() {
   ! git remote get-url --all "$TEST_DIR/fork.git" >/dev/null 2>&1
 
   run -0 gh-signoff
-  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
 @test "fork pull request signoff accepts a commit contained in the fork's tip" {
@@ -591,7 +591,7 @@ checkout_fork_pull_request() {
   track_url_remote "$TEST_DIR/fork.git" refs/heads/their-branch
 
   run -0 gh-signoff
-  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
 @test "fork pull request signoff still catches unpushed changes" {
@@ -600,10 +600,10 @@ checkout_fork_pull_request() {
   git commit --no-gpg-sign --allow-empty -m "Unpushed commit" >/dev/null
 
   run -1 gh-signoff
-  [[ "$output" == *"unpushed changes"* ]]
+  [[ "$output" == *"unpushed changes"* ]] || return 1
 
   run -0 gh-signoff -f
-  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
 @test "fork pull request signoff refuses when the fork's tip is not in this repository" {
@@ -618,10 +618,10 @@ checkout_fork_pull_request() {
   git -C "$TEST_DIR/contributor" push -q origin HEAD:refs/heads/their-branch
 
   run -1 gh-signoff
-  [[ "$output" == *"which is not in this repository"* ]]
+  [[ "$output" == *"which is not in this repository"* ]] || return 1
 
   run -0 gh-signoff -f
-  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
 @test "fork pull request signoff refuses when the tracked ref is absent from the fork" {
@@ -630,8 +630,8 @@ checkout_fork_pull_request() {
   git config branch.their-branch.merge refs/heads/never-pushed
 
   run -1 gh-signoff
-  [[ "$output" == *"unpushed changes"* ]]
-  [[ "$output" == *"refs/heads/never-pushed does not exist"* ]]
+  [[ "$output" == *"unpushed changes"* ]] || return 1
+  [[ "$output" == *"refs/heads/never-pushed does not exist"* ]] || return 1
 }
 
 @test "fork pull request signoff refuses when the fork cannot be reached" {
@@ -640,10 +640,10 @@ checkout_fork_pull_request() {
   track_url_remote "$TEST_DIR/no-such-fork.git" refs/heads/their-branch
 
   run -1 gh-signoff
-  [[ "$output" == *"could not be reached"* ]]
+  [[ "$output" == *"could not be reached"* ]] || return 1
 
   run -0 gh-signoff -f
-  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
 @test "fork pull request signoff refuses when the push destination is not that URL" {
@@ -656,36 +656,36 @@ checkout_fork_pull_request() {
   for mode in current nothing matching; do
     git config push.default "$mode"
     run -1 gh-signoff
-    [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+    [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]] || return 1
   done
   git config push.default simple
 
   git config branch.their-branch.pushremote "$TEST_DIR/elsewhere.git"
   run -1 gh-signoff
-  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]] || return 1
   git config branch.their-branch.pushremote "$TEST_DIR/fork.git"
 
   git config remote.pushDefault "$TEST_DIR/elsewhere.git"
   git config --unset branch.their-branch.pushremote
   run -1 gh-signoff
-  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]] || return 1
   git config --unset remote.pushDefault
 
   # url.*.pushInsteadOf rewrites push URLs, and git offers no way to expand
   # the push side of an anonymous remote to compare against
   git config "url.$TEST_DIR/elsewhere.git.pushInsteadOf" "$TEST_DIR/fork.git"
   run -1 gh-signoff
-  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]] || return 1
   git config --remove-section "url.$TEST_DIR/elsewhere.git"
 
   git config --unset branch.their-branch.merge
   run -1 gh-signoff
-  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]]
+  [[ "$output" == *"tracks $TEST_DIR/fork.git as a URL"* ]] || return 1
   git config branch.their-branch.merge refs/heads/their-branch
 
   # With nothing rerouting the push away from the tracked URL, the proof engages
   run -0 gh-signoff
-  [[ "$output" == *"Signed off on"* ]]
+  [[ "$output" == *"Signed off on"* ]] || return 1
 }
 
 @test "signoff fails with uncommitted changes message for dirty worktree" {


### PR DESCRIPTION
`gh signoff` cannot sign off on a branch checked out from a cross-repository (fork) pull request, and the error it gives points at the wrong thing.

## Reproduction

`gh pr checkout <n>` for a fork PR creates no named remote. It points the branch at a bare URL:

```
branch.<name>.remote     = https://github.com/someone/gh-signoff.git
branch.<name>.pushremote = https://github.com/someone/gh-signoff.git
branch.<name>.merge      = refs/heads/<their-branch>
```

git supports this natively, but a URL-valued remote has no remote-tracking ref, so every local check dead-ends:

- `git rev-parse --abbrev-ref @{push}` → `fatal: upstream branch 'refs/heads/<their-branch>' not stored as a remote-tracking branch`
- `@{upstream}` fails identically — there is no ref for either to name
- `upstream_fallback_is_safe()` calls `git remote get-url --all "$remote"` with the URL as the remote *name* → `error: No such remote 'https://github.com/...'` → returns 1
- `is_clean()` falls through to `cannot verify the current branch is pushed (@{push} does not resolve; check push.default and branch tracking; -f to override)`

That message sends you off to inspect `push.default` and branch tracking, both of which are already correct. The real cause is that the branch's remote is a URL, so there is no tracking ref to check against.

## Which option

**Option 2 — actually verify.** The remote is the only witness that HEAD is published, so ask it: one `git ls-remote <url> <ref>` on the ref the branch tracks. The network round trip happens only on this fallback path, after `@{push}` and the `@{upstream}` fallback have both come up empty; nothing about the normal path changes.

Option 1 (diagnose precisely) comes along for free: every remaining refusal now names its own cause and remedy.

## Soundness

The proof obligation is unchanged — never answer "pushed" for a SHA that is not on the push destination.

**What ls-remote proves.** It advertises ref *tips*, not history. Equality with HEAD would be sound but narrow. The stronger sound step: a repository holding a commit holds all of its ancestors, and a commit's parents are part of the object, so ancestry computed locally is ancestry on the remote. Once the advertised tip object is present in this repository, `git log <tip>..HEAD` empty proves HEAD is on that remote. That is *precisely* the inference `is_clean` already makes about a remote-tracking ref — the tip SHA merely arrives over the wire instead of from `refs/remotes`. So this reuses the existing containment check verbatim rather than adding a new kind of claim, and it means the reviewer with a local commit on top still gets the familiar "repository has unpushed changes".

**Where it stops.** When the advertised tip is *not* in this repository there is nothing to compute ancestry against, and proving containment would mean fetching. Signoff refuses and says so, suggesting `git fetch <url> <ref>`. Equality-with-HEAD is the special case of containment where the tip trivially is present, so nothing is lost.

**Which repository.** Proving HEAD is on the fork says nothing if a push would land elsewhere, so the routing allowlist mirrors `upstream_fallback_is_safe()` exactly: effective `push.default` simple, and the effective push remote (`branch.<name>.pushRemote` ?: `remote.pushDefault` ?: `branch.<name>.remote`) is this same URL. Deliberately conservative — `push.default=upstream` would also be provably fine here, but keeping one allowlist keeps one invariant to reason about.

Two URL-specific wrinkles:

- **Push refspecs need no check.** A `[remote "<url>"]` config section would make the URL a *configured* remote, which this path excludes: name-vs-URL is decided by enumerating `git remote`, not by pattern-matching the value.
- **`url.*.pushInsteadOf` does need one.** It rewrites push URLs, and git offers no way to expand the push side of an anonymous remote — `git remote get-url --push` requires a configured remote, and `git -c remote.probe.url=...` does not work either, since `remote_is_configured()` rejects command-line config. So any `pushInsteadOf` refuses rather than interrogate a URL a push would not use.

Nothing in `upstream_fallback_is_safe()` was touched, and the new path is only reached when it has already declined.

## Errors, before and after

Before, all of these produced the same misleading `check push.default and branch tracking`. After:

```
✓ Signed off on 4ec4b66f337e9b204e9521d3619931187c235903

Error: repository has unpushed changes
Error: repository has unpushed changes (refs/heads/never-pushed does not exist on <url>)
Error: cannot verify the current branch is pushed (branch their-branch tracks <url> as a URL,
  so there is no tracking ref, and that remote could not be reached; -f to override)
Error: cannot verify the current branch is pushed (branch their-branch tracks <url> as a URL,
  so there is no tracking ref, and its push destination is not provably that URL; add a named
  remote for it, or -f to override)
Error: cannot verify the current branch is pushed (<url> has refs/heads/their-branch at
  a76f785e14c7112ff70e16a5237a9325aa7882d9, which is not in this repository;
  git fetch <url> refs/heads/their-branch, or -f to override)
```

## Tests

Seven new bats tests reusing `make_nested_repo`/`add_bare_remote`, plus `track_url_remote` and `checkout_fork_pull_request` helpers that reconstruct the `gh pr checkout` config locally (git takes a path or a URL there identically). They cover the happy path — asserting first that `@{push}`, `@{upstream}` and `git remote get-url` all fail, i.e. that the repro is real — containment behind the fork's tip, unpushed local commits, a tip absent from this repository, a ref absent from the fork, an unreachable fork, and each rerouting refusal.

Bash 3/4/5 in Docker, `not ok` count:

```
bash3: 0
bash4: 0
bash5: 0
```
